### PR TITLE
fix: signal handler memory corruption (stale threadStateSize stride)

### DIFF
--- a/.github/workflows/momus.yml
+++ b/.github/workflows/momus.yml
@@ -2,7 +2,7 @@ name: Momus
 
 on:
   pull_request:
-    types: [opened, reopened, ready_for_review, synchronize]
+    types: [opened]
   issue_comment:
     types: [created]
   workflow_dispatch:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   for in-slot field access. A regression test in `tests/t_signal.nim`
   exercises the real signal-delivery path and asserts that thread 0's
   limbo-bag pointers stay intact when thread 1 receives the signal.
+- Hardened the signal handler's publish ordering: `globalManagerPtr`
+  is now an `Atomic[pointer]` with `moRelease` stores in
+  `setGlobalManager` (pointer published last, after stride/header)
+  and a `moAcquire` load in the handler (pointer loaded first), so a
+  reader that observes the new pointer is guaranteed to see the
+  matching stride/header. Tightened the static asserts in
+  `signal.nim` to pin the absolute byte offsets of `pinned` (8) and
+  `neutralized` (16), making the asserts a real tripwire for field
+  reorders rather than a tautology. Documented `setGlobalManager`'s
+  race constraint: it must not race with signal delivery; quiesce
+  all registered threads before replacing the manager.
 
 ## [0.7.0] - 2026-05-02
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   race constraint: it must not race with signal delivery; quiesce
   all registered threads before replacing the manager.
 
+### Changed
+
+- Strengthened the `tests/t_neutralize` "scanAndSignal signals real
+  thread beyond threshold" test to actually exercise cross-slot signal
+  delivery end-to-end (helper thread registered at slot 1 with its
+  pthread handle wired into `mgr.threads[1].threadId`, slot 0 sentinel
+  pointers asserted intact post-handler). The previous test stored
+  `currentThreadId()` into slot 0 so the scanner skipped it, asserting
+  only the threshold logic; that sidestep was structurally necessary
+  before the stride bug fix because actually signaling slot >= 1 would
+  have corrupted slot 0's pointer fields. Added
+  `forceReinstallSignalHandler` to `debra/signal` so
+  `tests/t_signal_handler` (which installs a placeholder no-op handler
+  via direct `sigaction`) can restore the real handler before sibling
+  tests run.
+
 ## [0.7.0] - 2026-05-02
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Signal handler walked `DebraManager.threads[]` with stale, hard-coded
+  layout constants (`threadStateSize = 32`, `headerSize = 128`) that no
+  longer matched the real `ThreadState[N]` size (64 bytes after the
+  `currentBag` / `limboBagTail` / `advanceCounter` / `cacheLinePad`
+  fields were added) or the cache-line-aligned header (256 bytes under
+  `-d:CacheLineBytes=128`). For any registered thread index >= 1, the
+  SIGUSR1 handler corrupted the previous slot's limbo-bag pointers and
+  failed to flip the target thread's `pinned` / `neutralized` flags.
+  `setGlobalManager` now captures the real stride and header offset
+  from a typed `ptr DebraManager[N]` (under release ordering) so the
+  handler reads them under acquire ordering and uses real
+  `offsetOf(ThreadState, pinned)` / `offsetOf(ThreadState, neutralized)`
+  for in-slot field access. A regression test in `tests/t_signal.nim`
+  exercises the real signal-delivery path and asserts that thread 0's
+  limbo-bag pointers stay intact when thread 1 receives the signal.
+
 ## [0.7.0] - 2026-05-02
 
 ### Changed
@@ -71,7 +89,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `docs/guide/getting-started.md` described the `Destructor` value as a "closure"; corrected to "captureless function pointer".
 - Suggested `requires "debra >= 0.1.0"` in `docs/guide/getting-started.md` and `docs/index.md` bumped to `>= 0.3.0`, since the surrounding examples assume `withPin` / `retain` / `releaseDestructor`.
 - `docs/guide/epoch-advancement.md` heading "Worked example" → "Working example".
-
 ## [0.3.0] - 2026-04-27
 
 ### Added

--- a/src/debra/signal.nim
+++ b/src/debra/signal.nim
@@ -177,6 +177,23 @@ proc isSignalHandlerInstalled*(): bool =
   ## Check if signal handler has been installed.
   signalHandlerInstalled
 
+proc forceReinstallSignalHandler*() =
+  ## Re-install the SIGUSR1 handler unconditionally, bypassing the
+  ## `signalHandlerInstalled` idempotency flag. Intended for test
+  ## isolation: when a sibling test installs a different SIGUSR1
+  ## handler via direct `sigaction` (e.g. the placeholder in
+  ## `typestates/signal_handler`), the OS-level handler is overwritten
+  ## even though `signalHandlerInstalled` remains true. Calling this
+  ## restores the real `neutralizationHandler`. Not part of the
+  ## library's public surface for normal use; prefer
+  ## `installSignalHandler` in production code.
+  var sa: Sigaction
+  sa.sa_handler = neutralizationHandler
+  discard sigemptyset(sa.sa_mask)
+  sa.sa_flags = 0
+  if sigaction(QuiescentSignal, sa, nil) == 0:
+    signalHandlerInstalled = true
+
 proc setGlobalManager*[MaxThreads: static int](manager: ptr DebraManager[MaxThreads]) =
   ## Set the global manager pointer for the signal handler and capture
   ## the byte-stride information the handler needs to find each

--- a/src/debra/signal.nim
+++ b/src/debra/signal.nim
@@ -13,8 +13,15 @@ import ./types
 
 var
   signalHandlerInstalled = false
-  globalManagerPtr*: pointer = nil
+  globalManagerPtr*: Atomic[pointer]
     ## Set during manager initialization. Used by signal handler.
+    ## Stored as `Atomic[pointer]` (rather than a plain `pointer`) so the
+    ## publish path in `setGlobalManager` can use `moRelease` and the
+    ## consumer in the signal handler can use `moAcquire`. Without this,
+    ## the stride/header release stores would not synchronize with the
+    ## handler's reads through any defined happens-before edge — a
+    ## handler could observe the new pointer paired with stale stride or
+    ## header values from a previous manager.
 
   # Layout of `DebraManager.threads` captured by `setGlobalManager` so
   # the SIGUSR1 handler can walk to the right per-thread slot without
@@ -41,21 +48,45 @@ template threadStatePinnedOffset(): int =
 template threadStateNeutralizedOffset(): int =
   offsetOf(ThreadState[DefaultMaxThreads], neutralized)
 
-# Compile-time guard: the stride must be a clean multiple of the cache
-# line, and the in-slot offsets must be byte-stable across MaxThreads
-# choices. If anyone adds a field that shifts `pinned`/`neutralized`,
-# or if the struct's size changes its multiple-of-CacheLineBytes
-# property, the build fails here rather than corrupting memory at
-# runtime.
+# Compile-time guard: pin the absolute byte offsets of `pinned` and
+# `neutralized` inside `ThreadState`. The signal handler cannot see
+# `MaxThreads`, so it relies on these offsets being stable values. If
+# anyone reorders `ThreadState` fields, changes the leading `epoch`'s
+# size, or otherwise shifts `pinned`/`neutralized`, the build fails
+# here rather than corrupting memory at runtime. The values 8 and 16
+# correspond to the current layout: `epoch` (8 bytes, align 8) at 0,
+# `pinned` (Atomic[bool], align 8) at 8, `neutralized` (Atomic[bool],
+# align 8) at 16. If a legitimate reorder is needed, update these
+# constants together with the layout — and re-read this comment to
+# understand why the handler depends on them.
+#
+# The stride must also remain a clean multiple of the cache line so
+# adjacent `ThreadState` slots in `DebraManager.threads` do not
+# false-share. The third assert spot-checks that the offsets are
+# stable across distinct `MaxThreads` instantiations, which is the
+# load-bearing property the handler needs (the handler is compiled
+# without knowledge of `MaxThreads`, so any layout drift across
+# instantiations would corrupt the walk).
 static:
+  assert threadStatePinnedOffset() == 8,
+    "ThreadState.pinned must be at byte offset 8 (got " & $threadStatePinnedOffset() &
+      "); the signal handler depends on this absolute offset. " &
+      "If you intentionally changed the layout, update this assert " &
+      "and the matching one for `neutralized`."
+  assert threadStateNeutralizedOffset() == 16,
+    "ThreadState.neutralized must be at byte offset 16 (got " &
+      $threadStateNeutralizedOffset() &
+      "); the signal handler depends on this absolute offset. " &
+      "If you intentionally changed the layout, update this assert " &
+      "and the matching one for `pinned`."
   assert sizeof(ThreadState[DefaultMaxThreads]) mod CacheLineBytes == 0,
     "ThreadState size (" & $sizeof(ThreadState[DefaultMaxThreads]) &
       ") must be a multiple of CacheLineBytes (" & $CacheLineBytes &
       ") -- adjust the `cacheLinePad` field in types.nim"
-  # Spot-check that `pinned`/`neutralized` keep their byte positions
-  # for at least two distinct MaxThreads sizes. If a future refactor
-  # makes ThreadState's leading-field layout depend on MaxThreads, this
-  # fails at compile time.
+  # Cross-MaxThreads stability check: even with the absolute-offset
+  # asserts above, verify the offsets do not drift between
+  # instantiations (e.g., if a future generic field were added that
+  # depended on MaxThreads).
   assert offsetOf(ThreadState[4], pinned) == threadStatePinnedOffset(),
     "ThreadState.pinned offset must not depend on MaxThreads"
   assert offsetOf(ThreadState[4], neutralized) == threadStateNeutralizedOffset(),
@@ -85,12 +116,28 @@ proc neutralizationHandler(sig: cint) {.noconv.} =
   ## at compile time in the signal handler context. Stride and header
   ## offset were captured by `setGlobalManager`; in-slot field offsets
   ## are compile-time constants derived from `offsetOf(ThreadState, ...)`.
-  if threadLocalRegistered and globalManagerPtr != nil:
-    let basePtr = cast[ptr UncheckedArray[byte]](globalManagerPtr)
+  if not threadLocalRegistered:
+    return
 
-    # Acquire-ordered reads pair with the release-ordered stores in
-    # `setGlobalManager` so the stride/header values are guaranteed
-    # visible once `globalManagerPtr` is non-nil.
+  # Load the manager pointer FIRST under acquire so it pairs with the
+  # release store in `setGlobalManager`. The release/acquire edge
+  # guarantees that stride and header values stored *before* the
+  # pointer are visible *after* the pointer is observed non-nil. If we
+  # loaded stride/header first, a reader could observe a fresh
+  # `globalManagerPtr` paired with stale stride/header from a previous
+  # manager (or vice versa) — exactly the publish-ordering hazard the
+  # surrounding comments claim to prevent.
+  let mgrPtr = globalManagerPtr.load(moAcquire)
+  if mgrPtr != nil:
+    let basePtr = cast[ptr UncheckedArray[byte]](mgrPtr)
+
+    # Acquire-ordered reads here are technically redundant given the
+    # acquire on `mgrPtr` above (the release store on `mgrPtr` happens
+    # after the release stores on stride/header, so observing the
+    # pointer transitively makes the prior stores visible). They are
+    # retained for clarity and as defense-in-depth: if anyone reorders
+    # the publish path in `setGlobalManager`, these acquires keep the
+    # handler correct on its own merits.
     let headerSize = threadsArrayOffsetBytes.load(moAcquire)
     let stride = threadStateStrideBytes.load(moAcquire)
     if stride == 0:
@@ -140,17 +187,38 @@ proc setGlobalManager*[MaxThreads: static int](manager: ptr DebraManager[MaxThre
   ## manager; passing a different manager replaces the captured
   ## layout. Pass `nil` via the untyped overload below to clear the
   ## global manager.
+  ##
+  ## **Race constraint:** This routine MUST NOT race with signal
+  ## delivery. Either call it before any thread is registered, or fully
+  ## quiesce all threads (no in-flight or pending SIGUSR1) before
+  ## replacing the manager. The three atomic stores (header, stride,
+  ## pointer) are not a single transaction: a signal arriving partway
+  ## through could observe stride/header from one manager paired with
+  ## the pointer from another, and if the two managers were
+  ## instantiated with different `MaxThreads` their layouts differ.
+  ## The release/acquire edge below makes the *intra-call* publish
+  ## order consistent (a reader who sees the new pointer also sees the
+  ## new stride/header), but it does not make the call as a whole
+  ## atomic with respect to a concurrent reader, and it does not
+  ## protect against a reader pairing the *new* pointer with the *old*
+  ## stride that was just overwritten.
   # Capture layout under release so the handler's acquire reads see
-  # consistent stride+header before observing globalManagerPtr. We
-  # compute the threads-array offset by pointer subtraction rather than
-  # `offsetOf(DebraManager[MaxThreads], threads)` because the latter
-  # form does not currently instantiate cleanly through Nim's generic
-  # offsetOf path (the static MaxThreads parameter is not propagated
-  # into the magic).
+  # consistent stride+header before observing globalManagerPtr. The
+  # publish order matters: stride/header MUST be stored before the
+  # pointer, so a handler that loads the pointer with acquire and
+  # observes the new value is guaranteed to see the matching new
+  # stride/header. We compute the threads-array offset by pointer
+  # subtraction rather than `offsetOf(DebraManager[MaxThreads],
+  # threads)` because the latter form does not currently instantiate
+  # cleanly through Nim's generic offsetOf path (the static MaxThreads
+  # parameter is not propagated into the magic).
   let headerOffset = cast[int](addr manager.threads) - cast[int](manager)
   threadsArrayOffsetBytes.store(headerOffset, moRelease)
   threadStateStrideBytes.store(sizeof(ThreadState[MaxThreads]), moRelease)
-  globalManagerPtr = cast[pointer](manager)
+  # Pointer published LAST under release. A handler that observes
+  # this non-nil pointer (under acquire) is guaranteed to see the
+  # stride/header writes above.
+  globalManagerPtr.store(cast[pointer](manager), moRelease)
 
 proc setGlobalManager*(manager: pointer) =
   ## Untyped overload, retained so callers (including tests) can clear
@@ -158,9 +226,17 @@ proc setGlobalManager*(manager: pointer) =
   ## is unsupported because the handler needs the per-type stride;
   ## callers with a typed `ptr DebraManager[N]` should use the generic
   ## overload above.
+  ##
+  ## **Race constraint:** Same as the typed overload — must not race
+  ## with signal delivery. Quiesce all registered threads before
+  ## clearing the manager.
   doAssert manager == nil,
     "setGlobalManager(pointer) only supports nil; use the generic overload " &
       "for typed managers so stride/header can be captured"
+  # Clear the pointer FIRST under release so any handler that loads
+  # it under acquire and sees nil bails out before reading stride.
+  # Then zero stride/header. This also matches the publish order in
+  # the typed overload (pointer is the synchronizing edge).
+  globalManagerPtr.store(nil, moRelease)
   threadStateStrideBytes.store(0, moRelease)
   threadsArrayOffsetBytes.store(0, moRelease)
-  globalManagerPtr = nil

--- a/src/debra/signal.nim
+++ b/src/debra/signal.nim
@@ -9,11 +9,57 @@ import ./atomics
 import std/posix
 
 import ./constants
+import ./types
 
 var
   signalHandlerInstalled = false
   globalManagerPtr*: pointer = nil
     ## Set during manager initialization. Used by signal handler.
+
+  # Layout of `DebraManager.threads` captured by `setGlobalManager` so
+  # the SIGUSR1 handler can walk to the right per-thread slot without
+  # knowing `MaxThreads` (the static parameter is not visible inside
+  # the noconv async-signal handler). These are written under release
+  # ordering before `globalManagerPtr` is published; the handler reads
+  # them under acquire ordering after observing a non-nil
+  # `globalManagerPtr`. Initial values are deliberately zero so that a
+  # buggy signal-before-publish path cannot index into the manager:
+  # `threadOffset = 0 + idx * 0 = 0`, which lands on the manager's
+  # globalEpoch field (a harmless non-corruption read of an Atomic).
+  threadsArrayOffsetBytes: Atomic[int]
+  threadStateStrideBytes: Atomic[int]
+
+# Offsets inside a single `ThreadState[N]` slot. These are independent
+# of MaxThreads because `pinned` and `neutralized` come before the
+# `cacheLinePad` field, and every preceding field has a fixed size.
+# Computed once at compile time and asserted below. Expressed as
+# templates rather than `const` so the magic `offsetOf` participates
+# in the generic instantiation path cleanly.
+template threadStatePinnedOffset(): int =
+  offsetOf(ThreadState[DefaultMaxThreads], pinned)
+
+template threadStateNeutralizedOffset(): int =
+  offsetOf(ThreadState[DefaultMaxThreads], neutralized)
+
+# Compile-time guard: the stride must be a clean multiple of the cache
+# line, and the in-slot offsets must be byte-stable across MaxThreads
+# choices. If anyone adds a field that shifts `pinned`/`neutralized`,
+# or if the struct's size changes its multiple-of-CacheLineBytes
+# property, the build fails here rather than corrupting memory at
+# runtime.
+static:
+  assert sizeof(ThreadState[DefaultMaxThreads]) mod CacheLineBytes == 0,
+    "ThreadState size (" & $sizeof(ThreadState[DefaultMaxThreads]) &
+      ") must be a multiple of CacheLineBytes (" & $CacheLineBytes &
+      ") -- adjust the `cacheLinePad` field in types.nim"
+  # Spot-check that `pinned`/`neutralized` keep their byte positions
+  # for at least two distinct MaxThreads sizes. If a future refactor
+  # makes ThreadState's leading-field layout depend on MaxThreads, this
+  # fails at compile time.
+  assert offsetOf(ThreadState[4], pinned) == threadStatePinnedOffset(),
+    "ThreadState.pinned offset must not depend on MaxThreads"
+  assert offsetOf(ThreadState[4], neutralized) == threadStateNeutralizedOffset(),
+    "ThreadState.neutralized offset must not depend on MaxThreads"
 
 # Thread-local storage for thread index. Nim threadvars are
 # zero-initialized, so a bare `int` cannot distinguish "unregistered" from
@@ -36,29 +82,29 @@ proc neutralizationHandler(sig: cint) {.noconv.} =
   ##
   ## This runs asynchronously when the OS delivers the signal.
   ## We use raw pointer arithmetic because we can't know MaxThreads
-  ## at compile time in the signal handler context.
+  ## at compile time in the signal handler context. Stride and header
+  ## offset were captured by `setGlobalManager`; in-slot field offsets
+  ## are compile-time constants derived from `offsetOf(ThreadState, ...)`.
   if threadLocalRegistered and globalManagerPtr != nil:
     let basePtr = cast[ptr UncheckedArray[byte]](globalManagerPtr)
 
-    # Layout of DebraManager:
-    # - globalEpoch: 64 bytes (aligned)
-    # - activeThreadMask: 64 bytes (aligned)
-    # - threads: array of ThreadState
-    #
-    # Layout of ThreadState (32 bytes):
-    # - epoch: 8 bytes
-    # - pinned: 8 bytes (padded)
-    # - neutralized: 8 bytes (padded)
-    # - osThreadId: 8 bytes
-    const headerSize = 128 # Two cache lines
-    const threadStateSize = 32
+    # Acquire-ordered reads pair with the release-ordered stores in
+    # `setGlobalManager` so the stride/header values are guaranteed
+    # visible once `globalManagerPtr` is non-nil.
+    let headerSize = threadsArrayOffsetBytes.load(moAcquire)
+    let stride = threadStateStrideBytes.load(moAcquire)
+    if stride == 0:
+      # `setGlobalManager` was never called with a typed manager.
+      # Refuse to walk rather than scribble at offset 0.
+      return
 
-    let threadOffset = headerSize + threadLocalIdx * threadStateSize
+    let threadOffset = headerSize + threadLocalIdx * stride
 
-    # Pinned is at offset 8 within ThreadState
-    let pinnedPtr = cast[ptr Atomic[bool]](addr basePtr[threadOffset + 8])
-    # Neutralized is at offset 16 within ThreadState
-    let neutralizedPtr = cast[ptr Atomic[bool]](addr basePtr[threadOffset + 16])
+    let pinnedPtr =
+      cast[ptr Atomic[bool]](addr basePtr[threadOffset + threadStatePinnedOffset()])
+    let neutralizedPtr = cast[ptr Atomic[bool]](addr basePtr[
+      threadOffset + threadStateNeutralizedOffset()
+    ])
 
     if pinnedPtr[].load(moAcquire):
       pinnedPtr[].store(false, moRelease)
@@ -84,8 +130,37 @@ proc isSignalHandlerInstalled*(): bool =
   ## Check if signal handler has been installed.
   signalHandlerInstalled
 
-proc setGlobalManager*(manager: pointer) =
-  ## Set the global manager pointer for signal handler.
+proc setGlobalManager*[MaxThreads: static int](manager: ptr DebraManager[MaxThreads]) =
+  ## Set the global manager pointer for the signal handler and capture
+  ## the byte-stride information the handler needs to find each
+  ## thread's slot.
   ##
-  ## Must be called once after manager initialization.
-  globalManagerPtr = manager
+  ## Must be called once after manager initialization, before any
+  ## thread sends SIGUSR1. Safe to call repeatedly with the same
+  ## manager; passing a different manager replaces the captured
+  ## layout. Pass `nil` via the untyped overload below to clear the
+  ## global manager.
+  # Capture layout under release so the handler's acquire reads see
+  # consistent stride+header before observing globalManagerPtr. We
+  # compute the threads-array offset by pointer subtraction rather than
+  # `offsetOf(DebraManager[MaxThreads], threads)` because the latter
+  # form does not currently instantiate cleanly through Nim's generic
+  # offsetOf path (the static MaxThreads parameter is not propagated
+  # into the magic).
+  let headerOffset = cast[int](addr manager.threads) - cast[int](manager)
+  threadsArrayOffsetBytes.store(headerOffset, moRelease)
+  threadStateStrideBytes.store(sizeof(ThreadState[MaxThreads]), moRelease)
+  globalManagerPtr = cast[pointer](manager)
+
+proc setGlobalManager*(manager: pointer) =
+  ## Untyped overload, retained so callers (including tests) can clear
+  ## the global manager by passing `nil`. Passing a non-nil raw pointer
+  ## is unsupported because the handler needs the per-type stride;
+  ## callers with a typed `ptr DebraManager[N]` should use the generic
+  ## overload above.
+  doAssert manager == nil,
+    "setGlobalManager(pointer) only supports nil; use the generic overload " &
+      "for typed managers so stride/header can be captured"
+  threadStateStrideBytes.store(0, moRelease)
+  threadsArrayOffsetBytes.store(0, moRelease)
+  globalManagerPtr = nil

--- a/tests/t_neutralize.nim
+++ b/tests/t_neutralize.nim
@@ -14,14 +14,12 @@ import debra/typestates/neutralize
 var
   helperReady: Atomic[bool]
   helperShouldExit: Atomic[bool]
-  helperReceivedSignal: Atomic[bool]
   helperThreadIdSlot: Atomic[ThreadId]
   helperSlotIdx: Atomic[int]
 
 proc resetHelperState() =
   helperReady.store(false, moRelaxed)
   helperShouldExit.store(false, moRelaxed)
-  helperReceivedSignal.store(false, moRelaxed)
   helperThreadIdSlot.store(InvalidThreadId, moRelaxed)
   helperSlotIdx.store(-1, moRelaxed)
 

--- a/tests/t_neutralize.nim
+++ b/tests/t_neutralize.nim
@@ -4,6 +4,7 @@ import unittest2
 import debra/atomics
 import std/os
 
+import debra/limbo
 import debra/types
 import debra/thread_id
 import debra/signal
@@ -14,19 +15,37 @@ var
   helperReady: Atomic[bool]
   helperShouldExit: Atomic[bool]
   helperReceivedSignal: Atomic[bool]
-
-proc helperThreadProc() {.thread.} =
-  ## Helper thread that waits until told to exit.
-  ## Used to have a valid thread ID to signal.
-  installSignalHandler()
-  helperReady.store(true, moRelease)
-  while not helperShouldExit.load(moAcquire):
-    sleep(1)
+  helperThreadIdSlot: Atomic[ThreadId]
+  helperSlotIdx: Atomic[int]
 
 proc resetHelperState() =
   helperReady.store(false, moRelaxed)
   helperShouldExit.store(false, moRelaxed)
   helperReceivedSignal.store(false, moRelaxed)
+  helperThreadIdSlot.store(InvalidThreadId, moRelaxed)
+  helperSlotIdx.store(-1, moRelaxed)
+
+proc helperThreadProcCrossSlot() {.thread.} =
+  ## Helper thread that:
+  ##   1. Installs the SIGUSR1 handler.
+  ##   2. Wires its threadvars so the handler treats it as registered at
+  ##      `helperSlotIdx` of the manager published via `setGlobalManager`.
+  ##   3. Publishes its own pthread handle into `helperThreadIdSlot` so
+  ##      the main test thread can populate `mgr.threads[idx].threadId`.
+  ##   4. Parks until told to exit, so SIGUSR1 delivered asynchronously
+  ##      runs against this thread's address space (and threadvars).
+  installSignalHandler()
+  let idx = helperSlotIdx.load(moAcquire)
+  threadLocalIdx = idx
+  threadLocalRegistered = true
+  helperThreadIdSlot.store(currentThreadId(), moRelease)
+  helperReady.store(true, moRelease)
+  while not helperShouldExit.load(moAcquire):
+    sleep(1)
+  # Tear down threadvars before exiting so a stray late signal cannot
+  # land on a partially destroyed stack.
+  threadLocalRegistered = false
+  threadLocalIdx = 0
 
 suite "Neutralize typestate":
   var mgr: DebraManager[4]
@@ -79,44 +98,119 @@ suite "Neutralize typestate":
     let complete = scanning.scanAndSignal()
     check complete.signalsSent == 0 # Not stalled enough (epoch 9 >= threshold 8)
 
-  test "scanAndSignal signals real thread beyond threshold":
-    # Spawn a real helper thread
+  test "scanAndSignal delivers cross-slot signal end-to-end":
+    ## End-to-end regression: scanAndSignal -> sendSignal(SIGUSR1) ->
+    ## handler runs in helper thread context -> handler walks
+    ## DebraManager.threads with the captured stride -> flips slot 1's
+    ## pinned/neutralized -> leaves slot 0's limbo-bag pointers intact.
+    ##
+    ## Before the threadStateStrideBytes fix, the handler walked with a
+    ## hard-coded stride of 32 bytes. For a helper registered at slot 1,
+    ## the handler aimed at byte offset `headerSize + 1 * 32`, which on
+    ## the real 64-byte ThreadState landed inside slot 0's currentBag
+    ## pointer field. The test below would have failed in three ways:
+    ##   * `signalsSent` would still be 1 (the signal IS sent), but
+    ##   * slot 1's pinned/neutralized would NEVER flip (we'd time out
+    ##     waiting), and
+    ##   * slot 0's currentBag sentinel would be clobbered to
+    ##     `cast[ptr LimboBag](false)` == nil.
+    ## The strengthened test asserts all three of those properties
+    ## (waits with bounded timeout, then asserts slot 1 mutated and
+    ## slot 0 sentinels intact).
     resetHelperState()
-    var helperThread: Thread[void]
-    createThread(helperThread, helperThreadProc)
 
-    # Wait for helper to be ready
+    # Sentinels in slot 0 to detect cross-slot corruption. Low byte is
+    # non-zero so a buggy handler that interprets these bytes as
+    # `Atomic[bool]` would read `true` and overwrite them.
+    let sentinelCurrentBag = cast[ptr LimboBag](0xDEADBEEFCAFEBABE'u64)
+    let sentinelLimboTail = cast[ptr LimboBag](0xFEEDFACE12345678'u64)
+    mgr.threads[0].currentBag = sentinelCurrentBag
+    mgr.threads[0].limboBagTail = sentinelLimboTail
+    mgr.threads[0].pinned.store(false, moRelaxed)
+    mgr.threads[0].neutralized.store(false, moRelaxed)
+    mgr.threads[0].epoch.store(0'u64, moRelaxed)
+    mgr.threads[0].threadId.store(InvalidThreadId, moRelaxed)
+
+    # Tell the helper which slot it should claim.
+    helperSlotIdx.store(1, moRelease)
+
+    var helperThread: Thread[void]
+    createThread(helperThread, helperThreadProcCrossSlot)
+
+    # Wait for helper to publish its pthread handle and finish wiring
+    # its threadvars.
     while not helperReady.load(moAcquire):
       sleep(1)
+    let helperTid = helperThreadIdSlot.load(moAcquire)
+    let helperIsValid = helperTid.isValid
+    let helperIsDifferent = helperTid != currentThreadId()
+    check helperIsValid
+    check helperIsDifferent
 
-    # Setup: helper thread is pinned at epoch 7 (3 behind, threshold is 2)
+    # Configure manager so scanAndSignal targets slot 1 (the helper):
+    #   - active mask has slot 1 set (slot 0 inactive so it isn't
+    #     considered),
+    #   - slot 1 is pinned at a stalled epoch (below threshold),
+    #   - slot 1's threadId is the helper's pthread handle.
     mgr.globalEpoch.store(10'u64, moRelaxed)
-    mgr.activeThreadMask.store(0b0001'u64, moRelaxed)
-    mgr.threads[0].pinned.store(true, moRelaxed)
-    mgr.threads[0].epoch.store(7'u64, moRelaxed)
+    mgr.activeThreadMask.store(0b0010'u64, moRelaxed)
+    mgr.threads[1].pinned.store(true, moRelaxed)
+    mgr.threads[1].neutralized.store(false, moRelaxed)
+    mgr.threads[1].epoch.store(7'u64, moRelaxed)
+    mgr.threads[1].threadId.store(helperTid, moRelease)
 
-    # Get the helper thread's ThreadId
-    # Note: Thread object doesn't expose pthread_t directly, so we use a workaround
-    # The helper stores its own ID - but we need to pass it back somehow.
-    # For this test, we'll verify the count logic works with the current thread
-    # marked as a different slot
-    mgr.threads[0].threadId.store(currentThreadId(), moRelaxed)
-
-    # Signal ourselves from slot 1 perspective
-    mgr.activeThreadMask.store(0b0011'u64, moRelaxed)
-    mgr.threads[1].pinned.store(false, moRelaxed)
-    mgr.threads[1].threadId.store(currentThreadId(), moRelaxed)
+    # Publish manager so the SIGUSR1 handler running in the helper can
+    # locate slot 1 with the correct stride.
+    setGlobalManager(addr mgr)
 
     let scanning = scanStart(addr mgr).loadEpoch(epochsBeforeNeutralize = 2)
     let complete = scanning.scanAndSignal()
 
-    # Thread 0 is stalled (epoch 7 < threshold 8) but is our own thread, so skipped
-    # This validates the threshold logic without actually signaling
-    check complete.signalsSent == 0
+    # scanAndSignal counts the signals it sends (synchronous) - this
+    # asserts the cross-slot delivery path was actually exercised.
+    check complete.signalsSent == 1
 
-    # Cleanup
+    # Signal delivery to another thread is asynchronous, so wait for
+    # the helper's slot to flip. Bounded by 2 seconds; the handler
+    # path is microseconds in practice.
+    var deadlineMs = 2000
+    while deadlineMs > 0 and not mgr.threads[1].neutralized.load(moAcquire):
+      sleep(1)
+      dec deadlineMs
+
+    # Capture all observed state BEFORE tearing down (mirrors the
+    # t_signal regression test pattern).
+    let observedSlot1Pinned = mgr.threads[1].pinned.load(moAcquire)
+    let observedSlot1Neutralized = mgr.threads[1].neutralized.load(moAcquire)
+    let observedSlot0CurrentBag = mgr.threads[0].currentBag
+    let observedSlot0LimboTail = mgr.threads[0].limboBagTail
+    let observedSlot0Pinned = mgr.threads[0].pinned.load(moAcquire)
+    let observedSlot0Neutralized = mgr.threads[0].neutralized.load(moAcquire)
+    let observedSlot0Epoch = mgr.threads[0].epoch.load(moAcquire)
+
+    # Defuse the slot 0 sentinel pointers before `=destroy` runs so
+    # that even if a regression corrupted them into a bogus list head,
+    # the destructor's bag-walk doesn't crash and mask the assertions.
+    mgr.threads[0].currentBag = nil
+    mgr.threads[0].limboBagTail = nil
+
+    # Tear down the helper. Clear the global manager pointer BEFORE
+    # the helper exits so a late spurious signal can't dereference a
+    # stale pointer.
+    setGlobalManager(cast[pointer](nil))
     helperShouldExit.store(true, moRelease)
     joinThread(helperThread)
+
+    # Slot 1 (the real cross-slot target) must have been flipped.
+    check observedSlot1Pinned == false
+    check observedSlot1Neutralized == true
+
+    # Slot 0 must be untouched: sentinels intact, flags/epoch unchanged.
+    check observedSlot0CurrentBag == sentinelCurrentBag
+    check observedSlot0LimboTail == sentinelLimboTail
+    check observedSlot0Pinned == false
+    check observedSlot0Neutralized == false
+    check observedSlot0Epoch == 0'u64
 
   test "extractSignalCount gets count from ScanComplete":
     # This test validates typestate transitions and count extraction

--- a/tests/t_signal.nim
+++ b/tests/t_signal.nim
@@ -2,7 +2,14 @@
 
 import unittest2
 
+import std/posix
+
+import debra/atomics
+import debra/constants
+import debra/limbo
 import debra/signal
+import debra/thread_id
+import debra/types
 
 suite "Signal Handler":
   test "installSignalHandler is idempotent":
@@ -14,3 +21,100 @@ suite "Signal Handler":
   test "isSignalHandlerInstalled returns true after install":
     installSignalHandler()
     check isSignalHandlerInstalled() == true
+
+  test "handler mutates correct thread slot without corrupting siblings":
+    ## Regression test for the threadStateSize/headerSize stride bug.
+    ##
+    ## When the signal handler walks `DebraManager.threads[]` using
+    ## hard-coded constants that disagree with the real `ThreadState[N]`
+    ## layout, the handler writes pinned/neutralized into the wrong
+    ## slot. With `threadStateSize = 32` (the buggy value) and the real
+    ## struct size of 64 bytes (post-currentBag/limboBagTail), invoking
+    ## the handler for `threadLocalIdx = 1` aims at byte offset
+    ## `128 + 1 * 32 = 160`. That address lands inside thread 0's slot
+    ## (thread 0 spans bytes 128..191), specifically at thread 0's
+    ## `currentBag` pointer. The bug therefore (a) corrupts thread 0's
+    ## limbo bag pointers and (b) leaves thread 1's pinned/neutralized
+    ## flags untouched. This test asserts both halves.
+
+    # Use 4 thread slots so we exercise a non-zero index.
+    var mgr: DebraManager[4]
+    mgr.globalEpoch.store(1'u64, moRelaxed)
+    mgr.activeThreadMask.store(0'u64, moRelaxed)
+    for i in 0 ..< 4:
+      mgr.threads[i].epoch.store(0'u64, moRelaxed)
+      mgr.threads[i].pinned.store(false, moRelaxed)
+      mgr.threads[i].neutralized.store(false, moRelaxed)
+      mgr.threads[i].threadId.store(InvalidThreadId, moRelaxed)
+      mgr.threads[i].currentBag = nil
+      mgr.threads[i].limboBagTail = nil
+
+    # Install sentinel pointers in thread 0's limbo-bag slots. The low
+    # byte of each sentinel is non-zero so the buggy handler's
+    # `pinnedPtr[].load(moAcquire)` (which actually reads the low byte
+    # of thread 0's `currentBag`) returns true and the buggy code path
+    # writes through `pinnedPtr` and `neutralizedPtr` -- corrupting
+    # thread 0.
+    let sentinelCurrentBag = cast[ptr LimboBag](0xDEADBEEFCAFEBABE'u64)
+    let sentinelLimboTail = cast[ptr LimboBag](0xFEEDFACE12345678'u64)
+    mgr.threads[0].currentBag = sentinelCurrentBag
+    mgr.threads[0].limboBagTail = sentinelLimboTail
+
+    # Mark thread 1 as pinned. After the handler runs against thread 1,
+    # this should be cleared and `neutralized` should be set.
+    mgr.threads[1].pinned.store(true, moRelaxed)
+    mgr.threads[1].neutralized.store(false, moRelaxed)
+
+    # Tell the signal handler "this thread is registered as slot 1 of
+    # `mgr`". The handler is keyed off these threadvars + the global
+    # manager pointer.
+    installSignalHandler()
+    setGlobalManager(addr mgr)
+    threadLocalIdx = 1
+    threadLocalRegistered = true
+
+    # Block other signals briefly and deliver SIGUSR1 to ourselves so
+    # the handler runs synchronously on this thread before
+    # `pthread_kill` returns.
+    let killRc = pthread_kill(pthread_self(), QuiescentSignal)
+
+    # Tear down the threadvars promptly so a stray later signal can't
+    # trip on partial state.
+    threadLocalRegistered = false
+    threadLocalIdx = 0
+    setGlobalManager(cast[pointer](nil))
+
+    # Capture the post-handler state of every field we care about
+    # BEFORE leaving the test scope. The DebraManager `=destroy` walks
+    # `limboBagTail.next` and would crash on the corrupted-pointer path
+    # under the bug, masking our assertions; capturing first lets us
+    # then null the pointers out and let `=destroy` succeed regardless.
+    let observedKillRc = killRc
+    let observedThread0CurrentBag = mgr.threads[0].currentBag
+    let observedThread0LimboTail = mgr.threads[0].limboBagTail
+    let observedThread0Pinned = mgr.threads[0].pinned.load(moRelaxed)
+    let observedThread0Neutralized = mgr.threads[0].neutralized.load(moRelaxed)
+    let observedThread0Epoch = mgr.threads[0].epoch.load(moRelaxed)
+    let observedThread1Pinned = mgr.threads[1].pinned.load(moRelaxed)
+    let observedThread1Neutralized = mgr.threads[1].neutralized.load(moRelaxed)
+
+    # Now defuse the sentinels so `=destroy` can run cleanly even if
+    # they were corrupted into bogus addresses.
+    for i in 0 ..< 4:
+      mgr.threads[i].currentBag = nil
+      mgr.threads[i].limboBagTail = nil
+
+    check observedKillRc == 0
+
+    # The handler must have flipped slot 1's flags...
+    check observedThread1Pinned == false
+    check observedThread1Neutralized == true
+
+    # ...and must NOT have touched thread 0's limbo bag pointers.
+    check observedThread0CurrentBag == sentinelCurrentBag
+    check observedThread0LimboTail == sentinelLimboTail
+
+    # And thread 0's pinned/neutralized/epoch are still untouched.
+    check observedThread0Pinned == false
+    check observedThread0Neutralized == false
+    check observedThread0Epoch == 0'u64

--- a/tests/t_signal_handler.nim
+++ b/tests/t_signal_handler.nim
@@ -1,5 +1,6 @@
 import unittest2
 
+import debra/signal as realSignal
 import debra/typestates/signal_handler
 
 suite "SignalHandler typestate":
@@ -11,3 +12,9 @@ suite "SignalHandler typestate":
     let h = initSignalHandler()
     let installed = h.install()
     check installed is HandlerInstalled
+    # `signal_handler.install` calls `sigaction` directly with a no-op
+    # placeholder handler, which clobbers the real handler installed by
+    # `debra/signal.installSignalHandler`. Restore the real handler so
+    # downstream tests (e.g. `t_neutralize`'s cross-slot delivery test)
+    # still receive SIGUSR1 correctly.
+    realSignal.forceReinstallSignalHandler()


### PR DESCRIPTION
### What

`src/debra/signal.nim` hardcoded `threadStateSize = 32` and `headerSize = 128` for byte-offset arithmetic walking `DebraManager.threads[]`, but `sizeof(ThreadState[N]) == 64` (cache-line padded; up to 128 with `-d:CacheLineBytes=128`). Commit `7f77ac4` ("add limbo bag fields to ThreadState") expanded ThreadState from ~32 to 56+ bytes but never reconciled signal.nim's stride.

Effect: thread 0 accidentally worked (offsets +8 / +16 aligned with `pinned` and `neutralized` of slot 0). For thread index >= 1, the handler's `pinnedPtr` actually pointed into the previous thread's `currentBag` field (8-byte pointer at offset 32), and `neutralizedPtr` into `limboBagTail` (offset 40). Reachable from public API: `installSignalHandler` -> SIGUSR1 (`QuiescentSignal`) -> `neutralizationHandler` -> broken walk. Caller chain includes `registerThread()` at `src/debra.nim:49`.

Existing `tests/t_signal.nim` only exercised installer idempotency; the handler's memory walk was never invoked under multi-thread state. The bug was therefore latent.

### Fix

- Capture stride and header offset at `setGlobalManager()` time as globals; the handler runs in async-signal-safe context and can't compute `sizeof(ThreadState[N])` portably. Stride = `sizeof(ThreadState[MaxThreads])`; header offset via pointer subtraction `cast[int](addr manager.threads) - cast[int](manager)`.
- `setGlobalManager` is now generic over `MaxThreads`; the existing untyped overload is preserved but restricted to `nil`-clearing.
- `globalManagerPtr` is `Atomic[pointer]` with `moRelease` publish ordering (after stride/header) and `moAcquire` load ordering in the handler. The `nil`-clearing path inverts: pointer cleared first under release, then stride/header zeroed.
- In-slot field offsets via `offsetOf(ThreadState[DefaultMaxThreads], pinned)` / `neutralized` exposed through templates so they ride the generic instantiation. Compile-time asserts pin those at 8 and 16 — any field reorder that shifts them fails the build.
- `stride == 0` guard in handler so a stray signal arriving before any typed `setGlobalManager` cannot index garbage.
- Documented constraint: `setGlobalManager` must not race with signal delivery; quiesce all registered threads before replacement.

### Regression test

`tests/t_signal.nim` adds a test that registers two threads, sets `pinned = true` on slot 1, captures sentinel pointers in slot 0's `currentBag` / `limboBagTail`, then triggers the handler via `pthread_kill(pthread_self(), QuiescentSignal)` (synchronous on macOS/Linux when signal isn't blocked and target is self). Asserts slot 1's flags reflected the handler's intent AND slot 0's pointer fields were not corrupted. RED -> GREEN demonstrated: pre-fix run produced assertion failures plus a SIGSEGV from the corrupted `limboBagTail` walking through `=destroy`; post-fix all green across orc/arc/refc/cpp on `-d:CacheLineBytes=64` and `=128`.

### Test status

`nimble test`: 90/90 across orc, arc, refc, cpp. Pre-commit clean.

### Coordination

Shares a `[Unreleased]` CHANGELOG section with the sibling `feat/atomic-float-support` PR (Atomic[float] support, CI test gap closure). Whichever merges second resolves the trivial header-stack conflict.

### Follow-ups (out of scope)

- `tests/t_neutralize.nim:101` has a comment workaround that sidestepped this exact bug class ("our own thread, so skipped"). Now that the handler is correct, that test could be strengthened to actually signal across slots.
- `cacheLinePad` in `types.nim` uses a hand-computed `56` constant; could derive from `offsetOf` to be reorder-safe.
