### PR TITLE
feat: Atomic[float32]/[float64] support; close CI test coverage gap

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Hardened `ThreadState.cacheLinePad` size derivation against future field additions. Padding length is now derived from `sizeof(ThreadStateLive[MaxThreads])` (a sibling type that mirrors `ThreadState`'s live fields) instead of a hand-summed `56` constant, so adding or removing fields automatically resizes the pad. A drift-detection `static: assert` fails fast at compile time if the two types fall out of sync.
+
 ### Fixed
 
 - Wired previously-orphaned test files into the nimble test runner: `tests/t_atomics`, `tests/t_atomics_dsl`, `tests/t_thread_id`, `tests/t_item_processing`, and `tests/t_lockfree_stack_typestates` were not imported by `tests/test.nim` and so were not exercised in CI. The compile-time-only negative test `tests/t_atomics_dsl_negative.nim` is now run via `nim check` from the `test` nimble task (it cannot be wired into `tests/test.nim` directly because doing so would import the DSL it asserts is not transitively reachable).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Wired previously-orphaned test files into the nimble test runner: `tests/t_atomics`, `tests/t_atomics_dsl`, `tests/t_thread_id`, `tests/t_item_processing`, and `tests/t_lockfree_stack_typestates` were not imported by `tests/test.nim` and so were not exercised in CI. The compile-time-only negative test `tests/t_atomics_dsl_negative.nim` is now run via `nim check` from the `test` nimble task (it cannot be wired into `tests/test.nim` directly because doing so would import the DSL it asserts is not transitively reachable).
+- `sendSignal(InvalidThreadId, ...)` now short-circuits with `ESRCH` instead of forwarding the zero handle into `pthread_kill`. Apple's libpthread happens to validate and return `ESRCH` for invalid handles, but glibc dereferences and may segfault. The corresponding test was previously fabricating a non-zero `pthread_t` (`999999`) and relying on the platform to gracefully reject it; that path is undefined behavior per POSIX (and *did* segfault on glibc, breaking CI). The test now exercises the `InvalidThreadId` path, which is the only invalid sentinel `sendSignal` supports.
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,7 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `Atomic[float32]` and `Atomic[float64]` support in `debra/atomics`.
   - `load`, `store`, `exchange`, and `compareExchangeStrong`/`compareExchangeWeak` accept floats through the existing generic path: the `nonAtomicType(T)` indirection routes float operations through the same-width integer atomic builtins via a bitcast, so `-0.0`, denormals, and NaN payloads round-trip bit-exactly. CAS uses bit-equality, matching `std::atomic<float>` semantics in C++ and the `AtomicU32::as_float`-style pattern in other languages: `+0.0` does NOT match `-0.0`, and two NaN values with distinct bit patterns do NOT compare equal.
-  - `fetchAdd[T: SomeFloat]` implemented via a `compareExchangeWeak` CAS-loop because GCC's `__atomic_fetch_add_n` builtin family is integer-only on float operands.
+  - `fetchAdd[T: SomeFloat]` implemented via a `compareExchangeWeak` CAS-loop because GCC's `__atomic_fetch_add_n` builtin family is integer-only on float operands. Unlike the pure bitwise ops above, `fetchAdd` performs an IEEE-754 float add: the returned old value is bit-exact, but the new stored value reflects FPU state (rounding mode, FTZ/DAZ flush-to-zero), does not preserve NaN payloads across the add, and produces +/-Inf on overflow.
   - The bitwise fetch ops (`fetchAnd`/`fetchOr`/`fetchXor`) and `fetchSub` are deliberately not provided for floats: bitwise ops have no meaningful float semantics, and `fetchSub` is expressible as `fetchAdd(-x)`.
 
 ## [0.3.0] - 2026-04-27

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,11 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.4.0] - 2026-04-27
-
 ### Fixed
 
-- Wired tests/t_atomics into the nimble test runner (was previously not exercised in CI).
+- Wired previously-orphaned test files into the nimble test runner: `tests/t_atomics`, `tests/t_atomics_dsl`, `tests/t_thread_id`, `tests/t_item_processing`, and `tests/t_lockfree_stack_typestates` were not imported by `tests/test.nim` and so were not exercised in CI. The compile-time-only negative test `tests/t_atomics_dsl_negative.nim` is now run via `nim check` from the `test` nimble task (it cannot be wired into `tests/test.nim` directly because doing so would import the DSL it asserts is not transitively reachable).
 
 ### Added
 
@@ -223,8 +221,7 @@ type
 - Docs deployment workflow for GitHub Pages
 - Integration tests
 
-[Unreleased]: https://github.com/elijahr/nim-debra/compare/v0.4.0...HEAD
-[0.4.0]: https://github.com/elijahr/nim-debra/compare/v0.3.0...v0.4.0
+[Unreleased]: https://github.com/elijahr/nim-debra/compare/v0.3.0...HEAD
 [0.3.0]: https://github.com/elijahr/nim-debra/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/elijahr/nim-debra/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/elijahr/nim-debra/compare/v0.1.2...v0.2.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [0.4.0] - 2026-04-27
 
+### Fixed
+
+- Wired tests/t_atomics into the nimble test runner (was previously not exercised in CI).
+
 ### Added
 
 - `Atomic[float32]` and `Atomic[float64]` support in `debra/atomics`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -257,7 +257,9 @@ type
 - Docs deployment workflow for GitHub Pages
 - Integration tests
 
-[Unreleased]: https://github.com/elijahr/nim-debra/compare/v0.3.1...HEAD
+[Unreleased]: https://github.com/elijahr/nim-debra/compare/v0.5.0...HEAD
+[0.5.0]: https://github.com/elijahr/nim-debra/compare/v0.4.0...v0.5.0
+[0.4.0]: https://github.com/elijahr/nim-debra/compare/v0.3.1...v0.4.0
 [0.3.1]: https://github.com/elijahr/nim-debra/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/elijahr/nim-debra/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/elijahr/nim-debra/compare/v0.2.0...v0.2.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.0] - 2026-04-27
+
+### Added
+
+- `Atomic[float32]` and `Atomic[float64]` support in `debra/atomics`.
+  - `load`, `store`, `exchange`, and `compareExchangeStrong`/`compareExchangeWeak` accept floats through the existing generic path: the `nonAtomicType(T)` indirection routes float operations through the same-width integer atomic builtins via a bitcast, so `-0.0`, denormals, and NaN payloads round-trip bit-exactly. CAS uses bit-equality, matching `std::atomic<float>` semantics in C++ and the `AtomicU32::as_float`-style pattern in other languages: `+0.0` does NOT match `-0.0`, and two NaN values with distinct bit patterns do NOT compare equal.
+  - `fetchAdd[T: SomeFloat]` implemented via a `compareExchangeWeak` CAS-loop because GCC's `__atomic_fetch_add_n` builtin family is integer-only on float operands.
+  - The bitwise fetch ops (`fetchAnd`/`fetchOr`/`fetchXor`) and `fetchSub` are deliberately not provided for floats: bitwise ops have no meaningful float semantics, and `fetchSub` is expressible as `fetchAdd(-x)`.
+
 ## [0.3.0] - 2026-04-27
 
 ### Added
@@ -210,7 +219,8 @@ type
 - Docs deployment workflow for GitHub Pages
 - Integration tests
 
-[Unreleased]: https://github.com/elijahr/nim-debra/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/elijahr/nim-debra/compare/v0.4.0...HEAD
+[0.4.0]: https://github.com/elijahr/nim-debra/compare/v0.3.0...v0.4.0
 [0.3.0]: https://github.com/elijahr/nim-debra/compare/v0.2.1...v0.3.0
 [0.2.1]: https://github.com/elijahr/nim-debra/compare/v0.2.0...v0.2.1
 [0.2.0]: https://github.com/elijahr/nim-debra/compare/v0.1.2...v0.2.0

--- a/debra.nimble
+++ b/debra.nimble
@@ -2,7 +2,7 @@
 
 # Package
 
-version = "0.3.0"
+version = "0.4.0"
 author = "elijahr <elijahr+debra@gmail.com>"
 description = "DEBRA+ safe memory reclamation for lock-free data structures"
 license = "MIT"

--- a/debra.nimble
+++ b/debra.nimble
@@ -28,8 +28,9 @@ task test, "Run tests with all memory managers":
   # (via `compiles`) that DSL symbols are NOT reachable from `debra/atomics`
   # alone. Wiring it into `tests/test.nim` would force the DSL to be imported
   # transitively and defeat the test.
-  echo "Checking tests/t_atomics_dsl_negative.nim (compile-time only)"
-  exec "nim check --threads:on --path:src tests/t_atomics_dsl_negative.nim"
+  echo "[nim check] verifying tests/t_atomics_dsl_negative.nim - DSL must NOT leak into debra/atomics core"
+  exec "nim check --threads:on --hints:off --warnings:off --path:src tests/t_atomics_dsl_negative.nim"
+  echo "[nim check] passed: DSL boundary intact"
   echo "All backends passed!"
 
 task testExamples, "Compile and run all example files":

--- a/debra.nimble
+++ b/debra.nimble
@@ -24,6 +24,12 @@ task test, "Run tests with all memory managers":
       " --threads:on --path:src -d:testing tests/test.nim"
   echo "Testing C++ backend"
   exec "nim cpp -r --threads:on --path:src -d:testing tests/test.nim"
+  # Negative compile-time test: must run via `nim check` because it asserts
+  # (via `compiles`) that DSL symbols are NOT reachable from `debra/atomics`
+  # alone. Wiring it into `tests/test.nim` would force the DSL to be imported
+  # transitively and defeat the test.
+  echo "Checking tests/t_atomics_dsl_negative.nim (compile-time only)"
+  exec "nim check --threads:on --path:src tests/t_atomics_dsl_negative.nim"
   echo "All backends passed!"
 
 task testExamples, "Compile and run all example files":

--- a/src/debra/atomics.nim
+++ b/src/debra/atomics.nim
@@ -442,6 +442,27 @@ proc fetchAdd*[T: SomeFloat](
   ##
   ## `order` is applied to the successful CAS; the failure order is
   ## derived per C11 (drops the release component).
+  ##
+  ## Bit-pattern fidelity caveat: `fetchAdd` performs an IEEE-754
+  ## float addition; unlike `load`/`store`/`exchange`/`compareExchange*`
+  ## (pure bitwise transfer), the bit-pattern guarantees do NOT apply
+  ## to the *new stored value*. Specifically:
+  ##
+  ##   * The returned old value IS bit-exact: it comes from a relaxed
+  ##     load before the add and reflects the pre-RMW storage bits
+  ##     verbatim (so e.g. a NaN payload in `loc` is preserved in the
+  ##     return value).
+  ##   * The new stored value is `old + v` computed by the FPU, which
+  ##     means: NaN payloads are not preserved across the add (e.g.
+  ##     `NaN_payload_A + 1.0` yields a quiet NaN with implementation-
+  ##     defined payload, not `payload_A`); denormal results may flush
+  ##     to zero if FTZ/DAZ is enabled in the calling thread's FPU
+  ##     state; the rounding mode is whatever the FPU is currently set
+  ##     to (round-to-nearest by default; modifiable via `fesetround`
+  ##     on x86 or FPCR on ARM); and overflow produces +/-Inf.
+  ##
+  ## The CAS-loop preserves atomicity; these caveats are inherent to
+  ## float arithmetic, not to this implementation.
   enforceAtomicConstraints(T)
   var old = load(loc, moRelaxed)
   while true:

--- a/src/debra/atomics.nim
+++ b/src/debra/atomics.nim
@@ -404,6 +404,54 @@ proc fetchXor*[T: SomeInteger](
   ))
 
 # ---------------------------------------------------------------------------
+# Numeric (SomeFloat)
+# ---------------------------------------------------------------------------
+#
+# `load`, `store`, `exchange`, and `compareExchange*` already accept
+# float32/float64 through the generic `T` overloads above: those route
+# through `nonAtomicType(T)` which maps any 4-byte type to `int32` and
+# any 8-byte type to `int64`, and the `cast[T](...)` on the way out
+# reinterprets the integer bits back as the float. The bit-level
+# transfer is exactly what we want for atomics on floats: -0.0 and NaN
+# payloads round-trip exactly, and CAS uses bit-equality (matching the
+# semantics of `std::atomic<float>` in C++ and `AtomicU32::as_float`
+# patterns in other languages). `assertLockFree`'s
+# `__atomic_always_lock_free(sizeof(T), 0)` is sizeof-based and
+# accepts floats on every target where the equivalent integer width
+# is lock-free.
+#
+# What's missing for floats is a hardware atomic add: GCC's
+# `__atomic_fetch_add_n` builtins are integer-only on float operands.
+# We provide `fetchAdd` for `SomeFloat` via a CAS-loop. Other
+# fetch-bitwise ops (`fetchAnd`/`fetchOr`/`fetchXor`) are deliberately
+# NOT provided for floats: bitwise operations on float values have no
+# meaningful semantics. `fetchSub` is omitted because `fetchAdd(-x)`
+# expresses the same operation cleanly.
+
+proc fetchAdd*[T: SomeFloat](
+    loc: var Atomic[T], v: T, order: static MemoryOrder = moSequentiallyConsistent
+): T {.inline.} =
+  ## Atomically add `v` to the float value at `loc` and return the
+  ## previous value. Implemented as a `compareExchangeWeak` CAS-loop
+  ## because GCC's `__atomic_fetch_add_n` is integer-only.
+  ##
+  ## Semantics: the read-add-CAS cycle is repeated until the CAS
+  ## succeeds, so the returned old value and the new stored value
+  ## together reflect a coherent atomic update of `loc`. Under
+  ## contention, the loop may iterate multiple times.
+  ##
+  ## `order` is applied to the successful CAS; the failure order is
+  ## derived per C11 (drops the release component).
+  enforceAtomicConstraints(T)
+  var old = load(loc, moRelaxed)
+  while true:
+    let desired = old + v
+    if compareExchangeWeak(loc, old, desired, order):
+      return old
+    # On failure, `old` was overwritten with the current value of
+    # `loc`; loop with the fresh value.
+
+# ---------------------------------------------------------------------------
 # Fences
 # ---------------------------------------------------------------------------
 

--- a/src/debra/thread_id.nim
+++ b/src/debra/thread_id.nim
@@ -34,7 +34,17 @@ proc isValid*(tid: ThreadId): bool =
 
 proc sendSignal*(tid: ThreadId, sig: cint): cint =
   ## Send a signal to the thread identified by tid.
-  ## Returns 0 on success, error code on failure.
+  ##
+  ## Returns 0 on success. Returns `ESRCH` immediately when `tid` equals
+  ## `InvalidThreadId`; otherwise returns the error code from `pthread_kill`.
+  ##
+  ## Note: POSIX explicitly leaves `pthread_kill` with an invalid `pthread_t`
+  ## as undefined behavior. Apple's libpthread happens to validate and return
+  ## `ESRCH`, but glibc dereferences the handle and may segfault. Callers
+  ## must only pass either a live thread's id or `InvalidThreadId`; passing a
+  ## fabricated non-zero handle is unsupported.
+  if not tid.isValid:
+    return ESRCH
   pthread_kill(tid.handle, sig)
 
 proc unsafeThreadId*(handle: Pthread): ThreadId =

--- a/src/debra/types.nim
+++ b/src/debra/types.nim
@@ -9,6 +9,19 @@ import ./limbo
 import ./thread_id
 
 type
+  ThreadStateLive[MaxThreads: static int] = object
+    ## Sibling type used SOLELY to derive the live-field byte total for
+    ## `ThreadState.cacheLinePad`. Must mirror `ThreadState`'s fields
+    ## exactly, minus `cacheLinePad`. The `static: assert` block below
+    ## catches drift between the two declarations.
+    epoch {.align: 8.}: Atomic[uint64]
+    pinned {.align: 8.}: Atomic[bool]
+    neutralized {.align: 8.}: Atomic[bool]
+    threadId {.align: 8.}: Atomic[ThreadId]
+    currentBag: ptr LimboBag
+    limboBagTail: ptr LimboBag
+    advanceCounter: uint64
+
   ThreadState*[MaxThreads: static int] = object
     ## Per-thread state tracked by the DEBRA manager.
     epoch* {.align: 8.}: Atomic[uint64] ## Last observed global epoch.
@@ -27,13 +40,21 @@ type
     # do not share a cache line. The `{.align: CacheLineBytes.}` on the
     # `threads` array only aligns the first element; without per-slot
     # padding, every slot after the first floats to its natural alignment
-    # and adjacent slots would false-share on every atomic write. The live
-    # fields above total 56 bytes today (4 atomics at 8 bytes, 2 pointers
-    # at 8 bytes, `advanceCounter` at 8 bytes); pad to `CacheLineBytes` so
-    # 64-byte (x86_64, AArch64) and 128-byte (Apple Silicon, PowerPC, or
-    # `-d:CacheLineBytes=128`) targets both work without manual edits.
-    # The static assert below catches any layout drift.
-    cacheLinePad: array[CacheLineBytes - 56, byte]
+    # and adjacent slots would false-share on every atomic write.
+    #
+    # Padding size is derived from `sizeof(ThreadStateLive[MaxThreads])`
+    # rather than a hand-summed constant, so adding/removing fields above
+    # automatically resizes the pad (provided the same change is mirrored
+    # into `ThreadStateLive`). The outer `mod CacheLineBytes` collapses
+    # the "exactly aligned" case to a 0-byte array instead of a full
+    # extra cache line. Works for 64-byte (x86_64, AArch64) and 128-byte
+    # (Apple Silicon, PowerPC, `-d:CacheLineBytes=128`) targets without
+    # manual edits. The static asserts below catch any drift.
+    cacheLinePad: array[
+      (CacheLineBytes - sizeof(ThreadStateLive[MaxThreads]) mod CacheLineBytes) mod
+        CacheLineBytes,
+      byte,
+    ]
 
   DebraManager*[MaxThreads: static int] = object
     ## Coordinates epoch-based reclamation across threads.
@@ -56,14 +77,27 @@ type
 
 # The cache-line alignment of `DebraManager.threads` only prevents false
 # sharing if each `ThreadState` is itself an exact multiple of the cache
-# line. If this static assertion ever fails, switch to padding `ThreadState`
-# (e.g. add a `_pad: array[CacheLineBytes - sizeof(...), byte]` field, or
-# wrap each slot in a padded object).
+# line. The first assertion below verifies that. The second assertion
+# verifies that `ThreadStateLive` mirrors `ThreadState`'s live fields
+# (everything except `cacheLinePad`); if a field is added/removed/resized
+# in one type but not the other, the drift trips a clear compile error
+# instead of silently producing the wrong padding size.
 static:
   assert sizeof(ThreadState[DefaultMaxThreads]) mod CacheLineBytes == 0,
     "ThreadState size (" & $sizeof(ThreadState[DefaultMaxThreads]) &
       ") must be a multiple of CacheLineBytes (" & $CacheLineBytes &
       ") to prevent false sharing across DebraManager.threads slots"
+  # Drift check: ThreadStateLive must contain the SAME fields as ThreadState
+  # minus cacheLinePad. If you add a field to one, add it to the other.
+  assert sizeof(ThreadState[DefaultMaxThreads]) -
+    sizeof(ThreadState[DefaultMaxThreads].cacheLinePad) ==
+    sizeof(ThreadStateLive[DefaultMaxThreads]),
+    "ThreadStateLive (" & $sizeof(ThreadStateLive[DefaultMaxThreads]) &
+      " bytes) is out of sync with ThreadState's live fields (" &
+      $(
+        sizeof(ThreadState[DefaultMaxThreads]) -
+        sizeof(ThreadState[DefaultMaxThreads].cacheLinePad)
+      ) & " bytes); update ThreadStateLive to mirror ThreadState"
 
 proc initDebraManager*[MaxThreads: static int](): DebraManager[MaxThreads] =
   ## Initialize a new DEBRA+ manager.

--- a/tests/t_atomics.nim
+++ b/tests/t_atomics.nim
@@ -3,6 +3,8 @@
 ## Tests for debra/atomics: a custom atomics module that rejects ref T,
 ## enforces lock-free at compile time, and validates memory orders per op.
 
+import std/math
+
 import unittest2
 
 import debra/atomics
@@ -656,6 +658,80 @@ suite "float fetchAdd":
     a.store(1.0'f32)
     check a.fetchAdd(2.0'f32, moAcquireRelease) == 1.0'f32
     check a.load() == 3.0'f32
+
+  test "float32 fetchAdd overflow produces +Inf":
+    # `fetchAdd` performs an IEEE-754 add; overflowing the format
+    # range produces +Inf. Document this as part of the FPU-state
+    # contract: the new stored value is whatever the FPU computes.
+    let maxF32 = cast[float32](0x7F7F_FFFF'u32) # largest finite float32
+    var a: Atomic[float32]
+    a.store(maxF32)
+    let old = a.fetchAdd(maxF32)
+    # Old value is bit-exact (relaxed-load contract): the pre-RMW
+    # storage bits round-trip into the return value.
+    check cast[uint32](old) == cast[uint32](maxF32)
+    # New stored value overflowed to +Inf.
+    check classify(a.load()) == fcInf
+    check a.load() > 0.0'f32
+
+  test "float64 fetchAdd overflow produces +Inf":
+    let maxF64 = cast[float64](0x7FEF_FFFF_FFFF_FFFF'u64)
+    var a: Atomic[float64]
+    a.store(maxF64)
+    let old = a.fetchAdd(maxF64)
+    check cast[uint64](old) == cast[uint64](maxF64)
+    check classify(a.load()) == fcInf
+    check a.load() > 0.0'f64
+
+  test "float32 fetchAdd of NaN: old value is bit-exact, new value is some NaN":
+    # Locks in the FPU-state contract for NaN inputs:
+    #   * The OLD value returned by fetchAdd is bit-exact (it comes
+    #     from a relaxed load before the add) - the original NaN
+    #     bit pattern is preserved in the return value.
+    #   * The NEW stored value is `NaN + 1.0`, which IEEE-754 says
+    #     is some NaN with implementation-defined payload. We do
+    #     NOT promise the payload is preserved across the add.
+    let nanBits: uint32 = 0x7FC0_0042'u32 # quiet NaN, payload 0x42
+    let nanVal = cast[float32](nanBits)
+    var a: Atomic[float32]
+    a.store(nanVal)
+    let old = a.fetchAdd(1.0'f32)
+    # Old value: bit-exact match to the original NaN.
+    check cast[uint32](old) == nanBits
+    # New stored value: some NaN (any bit pattern). Do NOT assert on
+    # the payload - that's implementation-defined.
+    check classify(a.load()) == fcNan
+
+  test "float64 fetchAdd of NaN: old value is bit-exact, new value is some NaN":
+    let nanBits: uint64 = 0x7FF8_0000_0000_0042'u64
+    let nanVal = cast[float64](nanBits)
+    var a: Atomic[float64]
+    a.store(nanVal)
+    let old = a.fetchAdd(1.0'f64)
+    check cast[uint64](old) == nanBits
+    check classify(a.load()) == fcNan
+
+  test "float64 fetchAdd of +Inf + (-Inf) yields NaN":
+    # IEEE-754: `+Inf + -Inf` is NaN (invalid operation). The old
+    # value returned must be the original +Inf bit pattern.
+    var a: Atomic[float64]
+    a.store(Inf)
+    let old = a.fetchAdd(NegInf)
+    # Old is bit-exact: the +Inf we stored.
+    check cast[uint64](old) == cast[uint64](float64(Inf))
+    check classify(old) == fcInf
+    check old > 0.0'f64
+    # New stored value: NaN (any pattern).
+    check classify(a.load()) == fcNan
+
+  test "float32 fetchAdd of +Inf + (-Inf) yields NaN":
+    var a: Atomic[float32]
+    a.store(float32(Inf))
+    let old = a.fetchAdd(float32(NegInf))
+    check cast[uint32](old) == cast[uint32](float32(Inf))
+    check classify(old) == fcInf
+    check old > 0.0'f32
+    check classify(a.load()) == fcNan
 
 when compileOption("threads"):
   suite "multi-threaded smoke":

--- a/tests/t_atomics.nim
+++ b/tests/t_atomics.nim
@@ -435,6 +435,228 @@ suite "static rejection":
   # is parsed unconditionally; failing builds on non-lock-free
   # primitives is exercised by the 32-bit CI lane in Phase D.
 
+suite "float load/store":
+  test "float32 load/store roundtrip with sentinel values":
+    var a: Atomic[float32]
+    # Zero
+    a.store(0.0'f32)
+    check a.load() == 0.0'f32
+    # Positive integer-valued float
+    a.store(1.0'f32)
+    check a.load() == 1.0'f32
+    # Negative
+    a.store(-1.0'f32)
+    check a.load() == -1.0'f32
+    # Approximate pi
+    a.store(3.1415927'f32)
+    check a.load() == 3.1415927'f32
+    # Negative zero: bit-distinct from +0.0 but `==` returns true.
+    # Verify both: `==` is true AND the bit pattern is preserved through
+    # the bitcast roundtrip.
+    a.store(-0.0'f32)
+    check a.load() == -0.0'f32
+    check cast[uint32](a.load()) == cast[uint32](-0.0'f32)
+    check cast[uint32](a.load()) != cast[uint32](0.0'f32)
+    # Smallest positive subnormal float32 (~1.4e-45). Subnormals have
+    # special bit layouts; verify bitcast preserves them exactly.
+    let subnormal = cast[float32](1'u32)
+    a.store(subnormal)
+    check cast[uint32](a.load()) == 1'u32
+
+  test "float32 NaN load/store preserves bit pattern":
+    # `==` on NaN returns false, so we can't compare with `==`. The
+    # bitcast roundtrip must preserve the exact NaN bit pattern.
+    var a: Atomic[float32]
+    let nanBits: uint32 = 0x7FC0_0000'u32 # canonical quiet NaN
+    let nanVal = cast[float32](nanBits)
+    a.store(nanVal)
+    check cast[uint32](a.load()) == nanBits
+
+  test "float64 load/store roundtrip with sentinel values":
+    var a: Atomic[float64]
+    a.store(0.0'f64)
+    check a.load() == 0.0'f64
+    a.store(1.0'f64)
+    check a.load() == 1.0'f64
+    a.store(-1.0'f64)
+    check a.load() == -1.0'f64
+    a.store(3.141592653589793'f64)
+    check a.load() == 3.141592653589793'f64
+    # Negative zero bit preservation.
+    a.store(-0.0'f64)
+    check a.load() == -0.0'f64
+    check cast[uint64](a.load()) == cast[uint64](-0.0'f64)
+    check cast[uint64](a.load()) != cast[uint64](0.0'f64)
+    # Smallest positive subnormal float64.
+    let subnormal = cast[float64](1'u64)
+    a.store(subnormal)
+    check cast[uint64](a.load()) == 1'u64
+
+  test "float64 NaN load/store preserves bit pattern":
+    var a: Atomic[float64]
+    let nanBits: uint64 = 0x7FF8_0000_0000_0000'u64 # canonical quiet NaN
+    let nanVal = cast[float64](nanBits)
+    a.store(nanVal)
+    check cast[uint64](a.load()) == nanBits
+
+  test "float load/store with explicit memory orders":
+    var a32: Atomic[float32]
+    a32.store(2.5'f32, moRelease)
+    check a32.load(moAcquire) == 2.5'f32
+    a32.store(7.0'f32, moRelaxed)
+    check a32.load(moRelaxed) == 7.0'f32
+    var a64: Atomic[float64]
+    a64.store(2.5'f64, moRelease)
+    check a64.load(moAcquire) == 2.5'f64
+
+suite "float exchange":
+  test "float32 exchange returns previous value":
+    var a: Atomic[float32]
+    a.store(10.5'f32)
+    check a.exchange(20.25'f32) == 10.5'f32
+    check a.load() == 20.25'f32
+
+  test "float64 exchange returns previous value":
+    var a: Atomic[float64]
+    a.store(10.5'f64)
+    check a.exchange(20.25'f64) == 10.5'f64
+    check a.load() == 20.25'f64
+
+  test "float exchange preserves -0.0 bit pattern":
+    # exchange must use bit-level transfer so -0.0 round-trips bit-exactly.
+    var a: Atomic[float32]
+    a.store(1.0'f32)
+    let prev = a.exchange(-0.0'f32)
+    check prev == 1.0'f32
+    check cast[uint32](a.load()) == cast[uint32](-0.0'f32)
+
+suite "float compareExchange":
+  test "float32 compareExchangeStrong success":
+    var a: Atomic[float32]
+    a.store(1.5'f32)
+    var expected = 1.5'f32
+    check a.compareExchangeStrong(expected, 2.5'f32) == true
+    check expected == 1.5'f32 # unchanged on success
+    check a.load() == 2.5'f32
+
+  test "float32 compareExchangeStrong failure overwrites expected":
+    var a: Atomic[float32]
+    a.store(1.5'f32)
+    var expected = 9.0'f32
+    check a.compareExchangeStrong(expected, 2.5'f32) == false
+    check expected == 1.5'f32 # overwritten with current value
+    check a.load() == 1.5'f32 # unchanged on failure
+
+  test "float64 compareExchangeStrong success":
+    var a: Atomic[float64]
+    a.store(1.5'f64)
+    var expected = 1.5'f64
+    check a.compareExchangeStrong(expected, 2.5'f64) == true
+    check expected == 1.5'f64
+    check a.load() == 2.5'f64
+
+  test "float64 compareExchangeStrong failure overwrites expected":
+    var a: Atomic[float64]
+    a.store(1.5'f64)
+    var expected = 9.0'f64
+    check a.compareExchangeStrong(expected, 2.5'f64) == false
+    check expected == 1.5'f64
+    check a.load() == 1.5'f64
+
+  test "float compareExchangeWeak two-order success":
+    var a: Atomic[float32]
+    a.store(1.5'f32)
+    var expected = 1.5'f32
+    var ok = false
+    for _ in 0 .. 32:
+      if a.compareExchangeWeak(expected, 2.5'f32, moAcquireRelease, moAcquire):
+        ok = true
+        break
+    check ok
+    check a.load() == 2.5'f32
+
+  test "float CAS is bit-equality: distinct NaN payloads do not match":
+    # CAS routes through the integer specialization, so equality is
+    # bit-equality. Two distinct NaN bit patterns will NOT compare
+    # equal even though `==` on floats also returns false for NaNs.
+    # The current value's bits must match `expected`'s bits exactly.
+    var a: Atomic[float32]
+    let nanA = cast[float32](0x7FC0_0000'u32) # quiet NaN, payload 0
+    let nanB = cast[float32](0x7FC0_0001'u32) # quiet NaN, payload 1
+    a.store(nanA)
+    var expected = nanB # different bit pattern
+    let ok = a.compareExchangeStrong(expected, 0.0'f32)
+    check ok == false
+    # On failure, expected is overwritten with the actual current bits.
+    check cast[uint32](expected) == cast[uint32](nanA)
+    # Storage unchanged.
+    check cast[uint32](a.load()) == cast[uint32](nanA)
+
+  test "float CAS is bit-equality: same NaN bit pattern matches":
+    # Counterpart: when the bit patterns DO match, CAS succeeds even
+    # though `==` on NaNs is false. This is the intended semantics:
+    # CAS sees raw bits, not float equality.
+    var a: Atomic[float32]
+    let nanBits: uint32 = 0x7FC0_0000'u32
+    let nanVal = cast[float32](nanBits)
+    a.store(nanVal)
+    var expected = nanVal # exact same bits
+    let ok = a.compareExchangeStrong(expected, 0.0'f32)
+    check ok == true
+    check a.load() == 0.0'f32
+
+  test "float CAS is bit-equality: +0.0 does not match -0.0":
+    # `0.0 == -0.0` is true semantically, but their bit patterns
+    # differ. CAS uses bit-equality, so a CAS expecting +0.0 against a
+    # storage holding -0.0 must FAIL. Document this behavior.
+    var a: Atomic[float32]
+    a.store(-0.0'f32)
+    var expected = 0.0'f32 # different bits from -0.0
+    let ok = a.compareExchangeStrong(expected, 1.0'f32)
+    check ok == false
+    # On failure, expected is overwritten with the current bits (-0.0).
+    check cast[uint32](expected) == cast[uint32](-0.0'f32)
+    check cast[uint32](a.load()) == cast[uint32](-0.0'f32)
+
+suite "float fetchAdd":
+  test "float32 fetchAdd returns old value and accumulates":
+    var a: Atomic[float32]
+    a.store(0.0'f32)
+    check a.fetchAdd(1.5'f32) == 0.0'f32
+    check a.load() == 1.5'f32
+    check a.fetchAdd(0.25'f32) == 1.5'f32
+    check a.load() == 1.75'f32
+
+  test "float32 fetchAdd with negative delta":
+    var a: Atomic[float32]
+    a.store(5.0'f32)
+    check a.fetchAdd(-0.5'f32) == 5.0'f32
+    check a.load() == 4.5'f32
+    check a.fetchAdd(-4.5'f32) == 4.5'f32
+    check a.load() == 0.0'f32
+
+  test "float64 fetchAdd returns old value and accumulates":
+    var a: Atomic[float64]
+    a.store(0.0'f64)
+    check a.fetchAdd(1.5'f64) == 0.0'f64
+    check a.load() == 1.5'f64
+    check a.fetchAdd(0.25'f64) == 1.5'f64
+    check a.load() == 1.75'f64
+
+  test "float64 fetchAdd with mixed signs":
+    var a: Atomic[float64]
+    a.store(10.0'f64)
+    check a.fetchAdd(-3.0'f64) == 10.0'f64
+    check a.fetchAdd(2.5'f64) == 7.0'f64
+    check a.fetchAdd(-9.5'f64) == 9.5'f64
+    check a.load() == 0.0'f64
+
+  test "float fetchAdd with explicit memory order":
+    var a: Atomic[float32]
+    a.store(1.0'f32)
+    check a.fetchAdd(2.0'f32, moAcquireRelease) == 1.0'f32
+    check a.load() == 3.0'f32
+
 when compileOption("threads"):
   suite "multi-threaded smoke":
     test "4 threads each fetchAdd 1000 increments share a counter":
@@ -454,3 +676,27 @@ when compileOption("threads"):
         joinThread(threads[i])
 
       check counter.load() == NumThreads * Increments
+
+    test "4 threads each fetchAdd 1.0 on a shared float64 counter":
+      # Float fetchAdd is implemented via CAS-loop, not a hardware atomic
+      # add, so this test exercises the loop's correctness under
+      # contention. With 4 threads each adding 1.0 a thousand times to a
+      # float64, the result must be exactly 4000.0 because float64 can
+      # represent integers up to 2^53 without loss; every intermediate
+      # sum is also representable exactly.
+      var counter: Atomic[float64]
+      counter.store(0.0'f64)
+      const NumThreads = 4
+      const Increments = 1000
+      var threads: array[NumThreads, Thread[ptr Atomic[float64]]]
+
+      proc worker(c: ptr Atomic[float64]) {.thread.} =
+        for _ in 0 ..< Increments:
+          discard c[].fetchAdd(1.0'f64, moAcquireRelease)
+
+      for i in 0 ..< NumThreads:
+        createThread(threads[i], worker, addr counter)
+      for i in 0 ..< NumThreads:
+        joinThread(threads[i])
+
+      check counter.load() == float64(NumThreads * Increments)

--- a/tests/t_thread_id.nim
+++ b/tests/t_thread_id.nim
@@ -1,6 +1,7 @@
 # tests/t_thread_id.nim
 
 import unittest2
+import std/posix
 
 import debra/thread_id
 
@@ -51,12 +52,13 @@ suite "ThreadId":
     # Should return 0 (success) for the current thread
     check rc == 0
 
-  test "sendSignal to invalid thread returns error":
-    # Sending a signal to an invalid/non-existent thread should fail
-    let invalidTid = unsafeThreadIdFromInt(999999)
-    let rc = invalidTid.sendSignal(0)
-    # Should return non-zero error code (typically ESRCH - No such process)
-    check rc != 0
+  test "sendSignal to InvalidThreadId returns ESRCH":
+    # InvalidThreadId is the only documented invalid sentinel; sendSignal
+    # short-circuits with ESRCH for it. Passing a fabricated non-zero
+    # handle to pthread_kill is UB per POSIX (Apple validates and returns
+    # ESRCH; glibc segfaults), so we don't test that path.
+    let rc = InvalidThreadId.sendSignal(0)
+    check rc == ESRCH
 
   test "unsafeThreadIdFromInt creates ThreadId from integer":
     let tid = unsafeThreadIdFromInt(12345)

--- a/tests/test.nim
+++ b/tests/test.nim
@@ -16,3 +16,7 @@ import ./t_convenience
 import ./t_refptr
 import ./t_integration
 import ./t_atomics
+import ./t_atomics_dsl
+import ./t_thread_id
+import ./t_item_processing
+import ./t_lockfree_stack_typestates

--- a/tests/test.nim
+++ b/tests/test.nim
@@ -15,3 +15,4 @@ import ./t_slot
 import ./t_convenience
 import ./t_refptr
 import ./t_integration
+import ./t_atomics


### PR DESCRIPTION
### What

Two related changes that share a `[Unreleased]` section.

**Atomic[float32] / Atomic[float64] support.** Discovery during implementation: the existing generic `Atomic[T]` path in `src/debra/atomics.nim` already supported float load/store/exchange/CAS via sizeof-based bitcast (`nonAtomicType(T)` maps to a same-width integer type, and the implementation casts on the loc pointer + `cast[T]` on read). So no new overloads were needed for those operations, they were untested but functional.

What was actually missing: `fetchAdd` for floats. Added `fetchAdd[T: SomeFloat]` via CAS-loop using `compareExchangeWeak` (cheaper on AArch64 LL/SC; canonical idiom). NOT added: `fetchSub` (use `fetchAdd(-x)`), `fetchAnd`/`fetchOr`/`fetchXor` (nonsensical on floats).

`fetchAdd[SomeFloat]` documents the FPU-state contract explicitly: load/store/exchange/compareExchange* preserve bit-exact (denormals, plus/minus zero, NaN payloads), but `fetchAdd` performs a real IEEE-754 add and is subject to FPU rounding mode, FTZ/DAZ flush-to-zero, NaN payload non-preservation, and overflow to plus/minus Inf. The CAS-loop preserves atomicity; these caveats are inherent to float arithmetic.

`debra.nimble` version bumped to **0.4.0** (minor: type bound is widened, no existing API broken).

**CI test coverage gap closure.** `tests/t_atomics.nim` was not imported by `tests/test.nim`, so atomics tests didn't run via `nimble test` or in CI: pre-existing gap dating to 0.3.0. Wired in. Surfaced no latent failures (scenario A: tests were dormant, not failing).

Same sweep found four more orphan files: `t_atomics_dsl.nim`, `t_item_processing.nim`, `t_lockfree_stack_typestates.nim`, `t_thread_id.nim`, all wired in. `t_atomics_dsl_negative.nim` is a compile-time-only test (uses `static: doAssert not compiles(...)` to verify DSL methods don't leak into core); cannot be wire-imported without defeating its assertions, so invoked via `nim check --threads:on --hints:off --warnings:off --path:src` from the `task test` block in `debra.nimble`. Failure-propagating via nimble's `exec`.

CHANGELOG moved entries from a prematurely-dated `[0.4.0] - 2026-04-27` header back under `[Unreleased]`. Footer link `[Unreleased]: ...compare/v0.3.0...HEAD` is correct as long as `v0.4.0` isn't tagged yet. Release ritual will rename + add new empty `[Unreleased]` at tag time.

### Test status

CI test count went from 89 to 159 (after t_atomics wired in) to 196 (after dormant sweep) to 202 per backend (after Inf/NaN/overflow tests). All 4 backend x MM combos (orc, arc, refc, cpp) pass clean. Pre-commit clean.

### Code review applied

Internal review surfaced two IMPORTANT items, both addressed in commit `11ad72e`:
- fetchAdd FPU-state contract docstring (the contract was correct in code; doc oversold bit-fidelity).
- Three new tests for `fetchAdd` of MAX_FLOAT (overflow to +Inf), NaN input (returned old value bit-exact, new stored value is NaN with implementation-defined payload, this confirms the relaxed-load contract is observable from outside), and `+Inf + (-Inf)` to NaN.

Plus minor: louder `nim check` echo + hints/warnings off for cleaner CI failure triage.

### Coordination

Shares `[Unreleased]` with sibling PR (signal handler memory corruption fix at https://github.com/elijahr/nim-debra/pull/3). Both PRs add CHANGELOG entries; second-merger resolves the trivial header conflict. Both ship in 0.4.0.

### Follow-ups (out of scope)

- `cacheLinePad: array[CacheLineBytes - 56, byte]` in `types.nim:36` uses a hand-computed `56`; could derive from `offsetOf` to be reorder-safe.
