### PR TITLE
docs: fix post-0.3.0 API drift in guides

### DIFF
--- a/docs/guide/epoch-advancement.md
+++ b/docs/guide/epoch-advancement.md
@@ -33,7 +33,7 @@ worker still calls `reclaimNow(handle)` on its own cadence to drain its own
 limbo bags; reclamation is per-thread (cross-thread reclamation is not
 supported, see [reclamation guide](reclamation.md)).
 
-## Worked example
+## Working example
 
 A queue's pop hot path that retires a segment when its last slot drains:
 

--- a/docs/guide/getting-started.md
+++ b/docs/guide/getting-started.md
@@ -7,7 +7,7 @@ This guide walks through setting up and using nim-debra in your lock-free data s
 Add nim-debra to your `.nimble` file:
 
 ```nim
-requires "debra >= 0.1.0"
+requires "debra >= 0.3.0"
 ```
 
 Or install globally:
@@ -38,7 +38,7 @@ The following example demonstrates the complete DEBRA+ lifecycle:
 - **Handle**: Per-thread registration for DEBRA operations
 - **Pin/Unpin**: Mark critical sections where shared data is accessed
 - **`retain[T]`**: GC-pin a `ref T` and return a raw `ptr T` suitable for atomic storage (`debra/refptr`)
-- **`releaseDestructor[T]()`**: Build a `Destructor` closure that pairs the `retain` at reclamation time
+- **`releaseDestructor[T]()`**: Return a captureless `Destructor` function pointer that pairs the `retain` at reclamation time
 - **Retire**: Mark a removed pointer (and its destructor) for later safe reclamation
 - **Reclaim**: Run pending destructors once all threads have advanced past the retiring epoch
 

--- a/docs/guide/integration.md
+++ b/docs/guide/integration.md
@@ -110,13 +110,13 @@ for the canonical pattern.
 
 ```nim
 # GOOD - process outside critical section
-let pinned = handle.pin()
+let pinned = unpinned(handle).pin()
 let data = loadSharedData()
 discard pinned.unpin()
 processData(data)
 
 # BAD - process inside critical section
-let pinned = handle.pin()
+let pinned = unpinned(handle).pin()
 let data = loadSharedData()
 processData(data)
 discard pinned.unpin()
@@ -154,7 +154,7 @@ Don't reclaim after every operation - amortize the cost.
 let value = queue.head.load(moAcquire).value
 
 # RIGHT - pin before access
-let pinned = handle.pin()
+let pinned = unpinned(handle).pin()
 let value = queue.head.load(moAcquire).value
 discard pinned.unpin()
 ```

--- a/docs/guide/neutralization.md
+++ b/docs/guide/neutralization.md
@@ -117,13 +117,13 @@ Avoid neutralization by keeping pin/unpin sections minimal:
 
 ```nim
 # GOOD - short critical section
-let pinned = handle.pin()
+let pinned = unpinned(handle).pin()
 let node = queue.dequeue()
 discard pinned.unpin()
 processNode(node)  # Outside critical section
 
 # BAD - long critical section
-let pinned = handle.pin()
+let pinned = unpinned(handle).pin()
 let node = queue.dequeue()
 processNode(node)  # Inside critical section!
 discard pinned.unpin()

--- a/docs/guide/retiring-objects.md
+++ b/docs/guide/retiring-objects.md
@@ -58,8 +58,9 @@ let ready = retireReady(pinned)
 discard ready.retire(cast[pointer](node), releaseDestructor[NodeObj]())
 ```
 
-`releaseDestructor[T]()` allocates a fresh closure on each call. Cache the
-result per type if you retire many objects in a hot loop.
+`releaseDestructor[T]()` returns a captureless `nimcall` function pointer:
+each `T` instantiation produces one proc address that is reused across calls,
+so handing it inline to `retire` does not allocate.
 
 ## Self-Referential Types
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -100,7 +100,7 @@ nimble install debra
 Or add to your `.nimble` file:
 
 ```nim
-requires "debra >= 0.1.0"
+requires "debra >= 0.3.0"
 ```
 
 ## Quick Links


### PR DESCRIPTION
### What

Six guide pages still carried pre-0.3.0 API patterns or inverted guidance. Every fix is a wording or one-line snippet change; no doc structure was reorganized.

**Broken snippets (would not compile against current API).** Five `let pinned = handle.pin()` examples across `integration.md` and `neutralization.md`. `pin` takes `sink Unpinned[MT]` (`src/debra/typestates/guard.nim:56`), so the right form is `unpinned(handle).pin()` — which is what every example under `examples/` already does. Switched to that form rather than `withPin` to keep the surrounding "GOOD vs BAD" framing intact.

**Inverted performance guidance.** `retiring-objects.md` warned that `releaseDestructor[T]()` "allocates a fresh closure on each call" and recommended caching it per type in hot loops. The implementation does the opposite: `src/debra/refptr.nim:118` returns a captureless `nimcall` proc, one address per `T` reused across calls. The README already describes it correctly ("captureless function pointer, so handing it to retire does not allocate"). Replaced the cache-it-yourself warning with the correct no-allocation note.

**Drift on the `Destructor` description.** `getting-started.md` called the value a "closure" — same root cause as above. Now reads "captureless function pointer".

**Stale `requires` pin.** `getting-started.md:10` and `index.md:103` both still listed `requires "debra >= 0.1.0"`. Technically satisfied by 0.3.0, but the surrounding code samples in those same pages assume `withPin` / `retain` / `releaseDestructor`, all of which post-date 0.1.0. Bumped to `>= 0.3.0`.

**Wording.** `epoch-advancement.md:36` "Worked example" → "Working example".

### Audit context

Two parallel `Explore` subagents audited every doc page in `docs/` plus `README.md` against the current source. Their findings were verified by reading the cited source lines and grepping `examples/`/`tests/` for actual usage before making edits. One agent claim — that the `let retired = ready.retire(...)` line in `index.md` would not compile — turned out to be a confabulation: the same pattern is used throughout `tests/t_retire.nim` and `tests/t_reclaim.nim`. Left alone.

A final post-edit grep turned up two more instances the original audit missed (the second `requires "debra >= 0.1.0"` in `index.md` and two more `handle.pin()` snippets in `neutralization.md`). Those are included in this PR; nothing else slipped through.

### Test status

Docs-only; no code touched. The mkdocs build is exercised by the `docs.yml` workflow on push.