### PR TITLE
Add client refcount + compareExchange alias; bump typestates to 0.6.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,12 +45,16 @@ jobs:
           nim-version: ${{ matrix.nim-version }}
 
       - name: Cache Nimble packages
+        # Cache key is bound to *.nimble so any dep change forces a fresh
+        # install. We deliberately do NOT use restore-keys: a partial-match
+        # restore brings in stale ~/.nimble/pkgs2 source clones, and nimble
+        # then resolves against the cached clone's tag set rather than
+        # re-fetching upstream — so newly-published dep versions are
+        # invisible. Full miss + fresh install is the correct behavior.
         uses: actions/cache@v4
         with:
           path: ~/.nimble
           key: ${{ matrix.runs-on }}-nimble-${{ matrix.nim-version }}-${{ hashFiles('*.nimble') }}
-          restore-keys: |
-            ${{ matrix.runs-on }}-nimble-${{ matrix.nim-version }}-
 
       - name: Install dependencies
         run: nimble install -y

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,19 @@
 name: release
 
+# Two release paths:
+#   1. push to main: parse the version from debra.nimble, idempotently
+#      create+push v{version} tag if it does not already exist, then
+#      create the GitHub Release.
+#   2. manual v* tag push: just create the GitHub Release.
+#
+# The two paths are merged into a single job because GITHUB_TOKEN-pushed
+# tags do not trigger downstream workflows. If we split into a separate
+# auto-tag workflow, the tag push would need a PAT (or workflow_dispatch
+# call) to fire the release step.
+
 on:
   push:
+    branches: [main]
     tags:
       - 'v*'
 
@@ -12,14 +24,49 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Resolve release tag
+        id: tag
+        run: |
+          set -euo pipefail
+          if [[ "$GITHUB_REF" == refs/tags/v* ]]; then
+            TAG="${GITHUB_REF#refs/tags/}"
+            echo "Triggered by tag push: $TAG"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          else
+            VERSION=$(grep -E '^version[[:space:]]*=' debra.nimble \
+              | sed -E 's/version[[:space:]]*=[[:space:]]*"([^"]+)".*/\1/' \
+              | head -n1)
+            if [ -z "$VERSION" ]; then
+              echo "::error::could not parse version from debra.nimble"
+              exit 1
+            fi
+            TAG="v$VERSION"
+            echo "Triggered by main push; parsed version $VERSION"
+            if git ls-remote --exit-code --tags origin "refs/tags/$TAG" >/dev/null 2>&1; then
+              echo "Tag $TAG already exists on remote; skipping release."
+              echo "skip=true" >> "$GITHUB_OUTPUT"
+            else
+              git config user.name "github-actions[bot]"
+              git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+              git tag -a "$TAG" -m "Release $TAG"
+              git push origin "$TAG"
+              echo "Created and pushed tag $TAG"
+              echo "skip=false" >> "$GITHUB_OUTPUT"
+            fi
+          fi
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 
       - name: Create GitHub Release
+        if: steps.tag.outputs.skip != 'true'
         uses: softprops/action-gh-release@v1
         with:
+          tag_name: ${{ steps.tag.outputs.tag }}
           generate_release_notes: true
           draft: false
-          prerelease: ${{ contains(github.ref, '-') }}
+          prerelease: ${{ contains(steps.tag.outputs.tag, '-') }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -62,7 +62,7 @@ jobs:
 
       - name: Create GitHub Release
         if: steps.tag.outputs.skip != 'true'
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.tag.outputs.tag }}
           generate_release_notes: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.5.0] - 2026-05-01
+
+### Added
+
+- Client refcount tracking on `DebraManager`. New procs `bindClient`, `unbindClient`, `clientCount`. The manager's destructor asserts `clientCount == 0` to catch the case where a client (e.g. a lock-free data structure) outlives its manager. Lock-free libraries built on nim-debra should bind in their constructor and unbind in their destructor.
+- `compareExchange` as an unsuffixed-name alias for `compareExchangeStrong` in `debra/atomics`. Convenience for clients migrating from `std/atomics`.
+
+### Changed
+
+- Bump minimum `typestates` to 0.6.0.
+
 ## [0.4.0] - 2026-04-30
 
 ### Added

--- a/debra.nimble
+++ b/debra.nimble
@@ -2,7 +2,7 @@
 
 # Package
 
-version = "0.4.0"
+version = "0.5.0"
 author = "elijahr <elijahr+debra@gmail.com>"
 description = "DEBRA+ safe memory reclamation for lock-free data structures"
 license = "MIT"
@@ -12,7 +12,7 @@ installExt = @["nim"]
 # Dependencies
 
 requires "nim >= 2.2.0"
-requires "typestates >= 0.2.1"
+requires "typestates >= 0.6.0"
 requires "unittest2 >= 0.2.0"
 
 # Tasks

--- a/src/debra.nim
+++ b/src/debra.nim
@@ -78,3 +78,31 @@ proc currentEpoch*[MaxThreads: static int](
 ): uint64 {.inline.} =
   ## Get current global epoch.
   manager.globalEpoch.load(moAcquire)
+
+proc bindClient*[MaxThreads: static int](
+    manager: var DebraManager[MaxThreads]
+) {.inline.} =
+  ## Register a client (e.g. a lock-free data structure) as bound to
+  ## this manager. Increments `boundClients` by 1.
+  ##
+  ## Lock-free libraries built on nim-debra should call `bindClient` in
+  ## their constructor and `unbindClient` in their destructor. The
+  ## manager's destructor asserts the count is zero, so a non-zero
+  ## count at teardown means a client outlived its manager: the client
+  ## would continue calling into freed manager state.
+  discard manager.boundClients.fetchAdd(1, moAcquireRelease)
+
+proc unbindClient*[MaxThreads: static int](
+    manager: var DebraManager[MaxThreads]
+) {.inline.} =
+  ## Unregister a client previously bound via `bindClient`. Decrements
+  ## `boundClients` by 1. See `bindClient` for usage.
+  discard manager.boundClients.fetchSub(1, moAcquireRelease)
+
+proc clientCount*[MaxThreads: static int](
+    manager: var DebraManager[MaxThreads]
+): int {.inline.} =
+  ## Number of clients currently bound to this manager. Relaxed load,
+  ## suitable for inspection and tests; not synchronized against
+  ## concurrent `bindClient` / `unbindClient`.
+  manager.boundClients.load(moRelaxed)

--- a/src/debra.nim
+++ b/src/debra.nim
@@ -97,7 +97,14 @@ proc unbindClient*[MaxThreads: static int](
 ) {.inline.} =
   ## Unregister a client previously bound via `bindClient`. Decrements
   ## `boundClients` by 1. See `bindClient` for usage.
-  discard manager.boundClients.fetchSub(1, moAcquireRelease)
+  ##
+  ## Asserts the previous count was positive: an underflow indicates an
+  ## unbalanced unbind (e.g. double-destroy of a client) and is caught
+  ## here with a precise stack trace, rather than later as a non-zero
+  ## value seen by the manager destructor.
+  let prev = manager.boundClients.fetchSub(1, moAcquireRelease)
+  doAssert prev > 0,
+    "unbindClient: boundClients underflow (was " & $prev & ", expected > 0); unbalanced bindClient/unbindClient"
 
 proc clientCount*[MaxThreads: static int](
     manager: var DebraManager[MaxThreads]

--- a/src/debra.nim
+++ b/src/debra.nim
@@ -104,7 +104,8 @@ proc unbindClient*[MaxThreads: static int](
   ## value seen by the manager destructor.
   let prev = manager.boundClients.fetchSub(1, moAcquireRelease)
   doAssert prev > 0,
-    "unbindClient: boundClients underflow (was " & $prev & ", expected > 0); unbalanced bindClient/unbindClient"
+    "unbindClient: boundClients underflow (was " & $prev &
+      ", expected > 0); unbalanced bindClient/unbindClient"
 
 proc clientCount*[MaxThreads: static int](
     manager: var DebraManager[MaxThreads]

--- a/src/debra/atomics.nim
+++ b/src/debra/atomics.nim
@@ -294,6 +294,34 @@ proc compareExchangeStrong*[T](
     toAtomMemModel(failure),
   )
 
+proc compareExchange*[T](
+    loc: var Atomic[T],
+    expected: var T,
+    desired: T,
+    success: static MemoryOrder,
+    failure: static MemoryOrder,
+): bool {.inline.} =
+  ## Strong compare-and-exchange. Unsuffixed-name alias for
+  ## `compareExchangeStrong`, matching the spelling used by clients
+  ## migrating from `std/atomics`.
+  compareExchangeStrong(loc, expected, desired, success, failure)
+
+proc compareExchange*[T](
+    loc: var Atomic[T], expected: var T, desired: T, order: static MemoryOrder
+): bool {.inline.} =
+  ## Strong CAS, single-order form. Failure order is derived from
+  ## success per C11 (drop the release component). Alias for
+  ## `compareExchangeStrong`.
+  compareExchangeStrong(loc, expected, desired, order)
+
+proc compareExchange*[T](
+    loc: var Atomic[T], expected: var T, desired: T
+): bool {.inline.} =
+  ## Strong CAS, default-order form. Equivalent to passing
+  ## `moSequentiallyConsistent` for both success and failure. Alias
+  ## for `compareExchangeStrong`.
+  compareExchangeStrong(loc, expected, desired)
+
 proc compareExchangeWeak*[T](
     loc: var Atomic[T],
     expected: var T,

--- a/src/debra/atomics.nim
+++ b/src/debra/atomics.nim
@@ -294,34 +294,6 @@ proc compareExchangeStrong*[T](
     toAtomMemModel(failure),
   )
 
-proc compareExchange*[T](
-    loc: var Atomic[T],
-    expected: var T,
-    desired: T,
-    success: static MemoryOrder,
-    failure: static MemoryOrder,
-): bool {.inline.} =
-  ## Strong compare-and-exchange. Unsuffixed-name alias for
-  ## `compareExchangeStrong`, matching the spelling used by clients
-  ## migrating from `std/atomics`.
-  compareExchangeStrong(loc, expected, desired, success, failure)
-
-proc compareExchange*[T](
-    loc: var Atomic[T], expected: var T, desired: T, order: static MemoryOrder
-): bool {.inline.} =
-  ## Strong CAS, single-order form. Failure order is derived from
-  ## success per C11 (drop the release component). Alias for
-  ## `compareExchangeStrong`.
-  compareExchangeStrong(loc, expected, desired, order)
-
-proc compareExchange*[T](
-    loc: var Atomic[T], expected: var T, desired: T
-): bool {.inline.} =
-  ## Strong CAS, default-order form. Equivalent to passing
-  ## `moSequentiallyConsistent` for both success and failure. Alias
-  ## for `compareExchangeStrong`.
-  compareExchangeStrong(loc, expected, desired)
-
 proc compareExchangeWeak*[T](
     loc: var Atomic[T],
     expected: var T,
@@ -376,6 +348,40 @@ proc compareExchangeWeak*[T](
   compareExchangeWeak(
     loc, expected, desired, moSequentiallyConsistent, moSequentiallyConsistent
   )
+
+# ---------------------------------------------------------------------------
+# compareExchange aliases (unsuffixed name, std/atomics-compatible spelling)
+# Defined after all compareExchangeStrong overloads so each alias resolves
+# against a fully-defined target.
+# ---------------------------------------------------------------------------
+
+proc compareExchange*[T](
+    loc: var Atomic[T],
+    expected: var T,
+    desired: T,
+    success: static MemoryOrder,
+    failure: static MemoryOrder,
+): bool {.inline.} =
+  ## Strong compare-and-exchange. Unsuffixed-name alias for
+  ## `compareExchangeStrong`, matching the spelling used by clients
+  ## migrating from `std/atomics`.
+  compareExchangeStrong(loc, expected, desired, success, failure)
+
+proc compareExchange*[T](
+    loc: var Atomic[T], expected: var T, desired: T, order: static MemoryOrder
+): bool {.inline.} =
+  ## Strong CAS, single-order form. Failure order is derived from
+  ## success per C11 (drop the release component). Alias for
+  ## `compareExchangeStrong`.
+  compareExchangeStrong(loc, expected, desired, order)
+
+proc compareExchange*[T](
+    loc: var Atomic[T], expected: var T, desired: T
+): bool {.inline.} =
+  ## Strong CAS, default-order form. Equivalent to passing
+  ## `moSequentiallyConsistent` for both success and failure. Alias
+  ## for `compareExchangeStrong`.
+  compareExchangeStrong(loc, expected, desired)
 
 # ---------------------------------------------------------------------------
 # Numeric (SomeInteger only)

--- a/src/debra/types.nim
+++ b/src/debra/types.nim
@@ -40,6 +40,12 @@ type
     globalEpoch* {.align: CacheLineBytes.}: Atomic[uint64] ## Global epoch counter.
     activeThreadMask* {.align: CacheLineBytes.}: Atomic[uint64]
       ## Bitmask of registered threads.
+    boundClients* {.align: CacheLineBytes.}: Atomic[int]
+      ## Refcount of clients (e.g. lock-free data structures) currently
+      ## bound to this manager via `bindClient` / `unbindClient`. The
+      ## destructor asserts this is zero so a client cannot outlive its
+      ## manager. Cache-line aligned to keep client bind/unbind off the
+      ## hot `globalEpoch` and `activeThreadMask` lines.
     threads* {.align: CacheLineBytes.}: array[MaxThreads, ThreadState[MaxThreads]]
       ## Per-thread state. Cache-line aligned to prevent false sharing
       ## across the per-thread slots (each slot is owned by a different
@@ -72,6 +78,7 @@ proc initDebraManager*[MaxThreads: static int](): DebraManager[MaxThreads] =
   ## "never observed" in thread state.
   result.globalEpoch.store(1'u64, moRelaxed)
   result.activeThreadMask.store(0'u64, moRelaxed)
+  result.boundClients.store(0, moRelaxed)
   for i in 0 ..< MaxThreads:
     result.threads[i].epoch.store(0'u64, moRelaxed)
     result.threads[i].pinned.store(false, moRelaxed)
@@ -89,9 +96,21 @@ proc `=destroy`*[MaxThreads: static int](manager: var DebraManager[MaxThreads]) 
   ## so concurrent retire during destruction is undefined). Process-exit
   ## and end-of-scope cleanup is the typical caller.
   ##
+  ## Asserts via `doAssert` that no clients are still bound (`boundClients
+  ## == 0`). A non-zero count means a data structure built on this manager
+  ## (e.g. a lock-free queue) is being destroyed after its manager, which
+  ## is a programmer error: the client will continue to call into freed
+  ## manager state. The assertion fires in release builds because the
+  ## downstream UB is silent.
+  ##
   ## Without this, retire-but-not-yet-reclaimed objects (and the limbo bags
   ## that hold them) leak under ASAN at exit. With aggressive Manual
   ## strategies or short-lived managers, the leak is observable.
+  let bound = manager.boundClients.load(moAcquire)
+  doAssert bound == 0,
+    "DebraManager destroyed while " & $bound &
+      " client(s) still bound; clients (e.g. lock-free data structures) " &
+      "must be torn down before their manager"
   for i in 0 ..< MaxThreads:
     var bag = manager.threads[i].limboBagTail
     while bag != nil:

--- a/src/debra/typestates/manager.nim
+++ b/src/debra/typestates/manager.nim
@@ -39,6 +39,7 @@ proc initialize*[MaxThreads: static int](
   let mgr = ctx.manager
   mgr.globalEpoch.store(1'u64, moRelaxed)
   mgr.activeThreadMask.store(0'u64, moRelaxed)
+  mgr.boundClients.store(0, moRelaxed)
   for i in 0 ..< MaxThreads:
     mgr.threads[i].epoch.store(0'u64, moRelaxed)
     mgr.threads[i].pinned.store(false, moRelaxed)

--- a/tests/t_bind_client.nim
+++ b/tests/t_bind_client.nim
@@ -18,6 +18,21 @@ suite "Client refcount (bindClient / unbindClient / clientCount)":
     mgr.unbindClient()
     check mgr.clientCount() == 0
 
+  test "unbindClient underflow fires AssertionDefect":
+    # An unbalanced unbindClient (no matching bindClient) must trip the
+    # underflow assertion at the moment of the bug, rather than slip
+    # through to be detected later by the manager destructor.
+    var mgr = initDebraManager[4]()
+    var fired = false
+    try:
+      mgr.unbindClient()
+    except AssertionDefect:
+      fired = true
+    check fired
+    # Restore the count so the manager destructor does not also fire
+    # (boundClients went from 0 to -1; bring it back to 0).
+    mgr.bindClient()
+
   test "destructor fires when clients are still bound":
     # The =destroy hook on DebraManager does a `doAssert
     # boundClients == 0`, which raises AssertionDefect (a Defect, not

--- a/tests/t_bind_client.nim
+++ b/tests/t_bind_client.nim
@@ -1,0 +1,35 @@
+import unittest2
+import debra
+import debra/atomics
+
+import debra/types
+
+suite "Client refcount (bindClient / unbindClient / clientCount)":
+  test "newly initialized manager has zero clients":
+    var mgr = initDebraManager[4]()
+    check mgr.clientCount() == 0
+
+  test "bindClient increments and unbindClient decrements":
+    var mgr = initDebraManager[4]()
+    mgr.bindClient()
+    mgr.bindClient()
+    check mgr.clientCount() == 2
+    mgr.unbindClient()
+    mgr.unbindClient()
+    check mgr.clientCount() == 0
+
+  test "destructor fires when clients are still bound":
+    # The =destroy hook on DebraManager does a `doAssert
+    # boundClients == 0`, which raises AssertionDefect (a Defect, not
+    # a CatchableError). We exercise the assertion by leaking a
+    # bind in a scope that goes out of scope inside a try/except
+    # AssertionDefect block.
+    var fired = false
+    try:
+      block:
+        var mgr = initDebraManager[4]()
+        mgr.bindClient()
+        # Manager goes out of scope here with boundClients == 1.
+    except AssertionDefect:
+      fired = true
+    check fired

--- a/tests/test.nim
+++ b/tests/test.nim
@@ -16,3 +16,4 @@ import ./t_convenience
 import ./t_refptr
 import ./t_integration
 import ./t_backoff
+import ./t_bind_client


### PR DESCRIPTION
Adds bidirectional client-refcount tracking on \`DebraManager\` so lock-free clients (e.g. lockfreequeues' unbounded queues) can detect manager-destroyed-before-client at the source rather than as a use-after-free.

### New API

- \`bindClient(manager)\` / \`unbindClient(manager)\` / \`clientCount(manager)\` — clients call \`bindClient\` from their constructor and \`unbindClient\` from their destructor.
- The manager's \`=destroy\` now \`doAssert\`s that \`clientCount == 0\`. If a manager is destroyed while clients are still bound, the assertion fires immediately with a count, instead of leaving dangling references that surface later as a UAF.
- \`compareExchange\` added as an unsuffixed-name alias for \`compareExchangeStrong\` in \`debra/atomics\` (three overloads matching the existing CAS shape). Removes a small migration-friction shim that downstream clients had been keeping around.

### Dependency bump

\`typestates\` minimum bumped \`>= 0.2.1\` → \`>= 0.6.0\`. Clean upgrade — no transition signatures or proc bodies changed; reachability/match-macro/state-aware-error features in 0.5 and the opaqueStates lint in 0.6 are all opt-in or warning-only.

### Tests

Added \`tests/t_bind_client.nim\` covering: zero-on-init, balanced bind/unbind, destructor assertion fires when clients are still bound. Full \`nimble test\` suite (orc, arc, atomicArc, refc, C++) is 95/95 passing.

### Versioning

Bumped to 0.5.0 (additive API + new runtime invariant for manager teardown order).

### Companion PR

This is the dependency half of a coordinated change. Once tagged, the lockfreequeues PR (https://github.com/elijahr/lockfreequeues/pulls — branch \`feat/ergonomics\`) consumes \`debra >= 0.5.0\` to wire its new auto-create / auto-register API.