### PR TITLE
fix: data race on signalHandlerInstalled flag

### DIFF
--- a/src/debra/signal.nim
+++ b/src/debra/signal.nim
@@ -12,7 +12,15 @@ import ./constants
 import ./types
 
 var
-  signalHandlerInstalled = false
+  signalHandlerInstalled: Atomic[bool]
+    ## Process-wide idempotency flag for the SIGUSR1 handler. Multiple
+    ## threads may race into `installSignalHandler` (each thread calls it
+    ## from `registerThread`), so the flag must be atomic. The
+    ## load/store ordering is acquire/release, but the install itself is
+    ## not guarded by CAS: a benign double-install can happen if two
+    ## threads both observe the flag false before either stores true.
+    ## That is harmless because `sigaction` is thread-safe and re-arming
+    ## the same handler is idempotent at the OS level.
   globalManagerPtr*: Atomic[pointer]
     ## Set during manager initialization. Used by signal handler.
     ## Stored as `Atomic[pointer]` (rather than a plain `pointer`) so the
@@ -162,7 +170,14 @@ proc installSignalHandler*() =
   ##
   ## Safe to call multiple times - subsequent calls are no-ops.
   ## Called automatically during first DebraManager initialization.
-  if signalHandlerInstalled:
+  ##
+  ## Thread-safety: the `signalHandlerInstalled` flag is `Atomic[bool]`,
+  ## acquire-loaded for the fast-path bail-out and release-stored after
+  ## a successful `sigaction`. Two threads may both observe the flag
+  ## false and both call `sigaction`; that is benign because
+  ## `sigaction` is thread-safe and re-arming the same handler is
+  ## idempotent at the OS level.
+  if signalHandlerInstalled.load(moAcquire):
     return
 
   var sa: Sigaction
@@ -171,11 +186,11 @@ proc installSignalHandler*() =
   sa.sa_flags = 0 # No SA_RESTART - we want operations to be interrupted
 
   if sigaction(QuiescentSignal, sa, nil) == 0:
-    signalHandlerInstalled = true
+    signalHandlerInstalled.store(true, moRelease)
 
 proc isSignalHandlerInstalled*(): bool =
   ## Check if signal handler has been installed.
-  signalHandlerInstalled
+  signalHandlerInstalled.load(moAcquire)
 
 proc forceReinstallSignalHandler*() =
   ## Re-install the SIGUSR1 handler unconditionally, bypassing the
@@ -192,7 +207,7 @@ proc forceReinstallSignalHandler*() =
   discard sigemptyset(sa.sa_mask)
   sa.sa_flags = 0
   if sigaction(QuiescentSignal, sa, nil) == 0:
-    signalHandlerInstalled = true
+    signalHandlerInstalled.store(true, moRelease)
 
 proc setGlobalManager*[MaxThreads: static int](manager: ptr DebraManager[MaxThreads]) =
   ## Set the global manager pointer for the signal handler and capture


### PR DESCRIPTION
## What

Fix data race on `signalHandlerInstalled` flag in `src/debra/signal.nim`.

`installSignalHandler` is called from every thread's `registerThread`. The
flag was a plain `bool` — concurrent threads racing the unguarded read+write.

Switch to `Atomic[bool]`:
- Read at the fast-path bail-out: `.load(moAcquire)`.
- Write after `sigaction`: `.store(true, moRelease)`.
- Same change applied to `isSignalHandlerInstalled` and `forceReinstallSignalHandler`.

The install itself is intentionally **not** CAS-guarded. A benign double-install
can happen if two threads both observe the flag false before either stores true.
Harmless because `sigaction` is thread-safe and re-arming the same handler is
idempotent at the OS level. Inline doc comments explain the discipline.

## How verified

Found via TSAN on lockfreequeues v4.3 SPMC threaded test (downstream consumer of
nim-debra). TSAN trace pointed exactly at this race:

- Read: `signal.nim:165` in `installSignalHandler` (the bool check)
- Write: `signal.nim:174` in `installSignalHandler` (the bool assign)
- Both stacks via `debra::registerThread` from concurrent threads.

Validation (downstream test):

- Pre-fix: 9/10 + 1 hang in 10 TSAN iterations (race surfaces reliably).
- Post-fix: 10/10 clean.
- Focused regression: 7/7 PASS across sipmuc single + threaded (default + atomicArc), padding (default + CacheLineBytes=128), spmc typestate tests.
- Disassembly-level verification: post-fix `installSignalHandler` calls `atomics::load_smoAcquire...`; pre-fix uses plain `ldrb` on the flag.

## Related

Sibling of the bfd05a7 / 802f3b4 fix (signal handler memory corruption /
threadStateSize stride); same family of "signal handler init is implicitly
multi-threaded" defect surface.

Suggests a 0.7.3 version bump so downstream `lockfreequeues` can pin
`requires "debra >= 0.7.3"`. Version bump not included in this PR — left to
maintainer judgment whether to include here or as a follow-on.
