### PR TITLE
0.8.0: PinnedScope RAII guard + PinScopeCardinality (CC) typestate axis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
         uses: pre-commit/action@v3.0.1
 
       - name: Install typestates
-        run: nimble install -y "typestates@0.7.1"
+        run: nimble install -y "typestates@>= 0.10.0"
 
       - name: Typestates verify
         run: typestates verify -W --format=github src/

--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,10 @@ tests/test
 !tests/test.nim
 ## Nested test binaries
 tests/**/[a-z_]*
+# `tests/**/[a-z_]*` also matches subdirectories themselves; git's
+# negation can't re-include files inside a directory excluded by an
+# earlier rule. Re-include directories first, then re-include .nim files.
+!tests/**/
 !tests/**/*.nim
 ## Debug binaries and symbols
 tests/debug_*

--- a/.gitignore
+++ b/.gitignore
@@ -56,6 +56,7 @@ docs/plans/
 /logs
 deps/
 nimble.paths
+config.nims
 
 # Atlas local config
 nim.cfg

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   `Retired`, `Registered`, `DebraManager`, `PinnedScope`. The default
   preserves source-compatibility for all single-cardinality call sites;
   multi-pin patterns must opt in with explicit `[N, ccMulti]`.
+- `bindClient`, `unbindClient`, `advance`, `currentEpoch`,
+  `clientCount`, and `initDebraManager` are now generic over
+  `CC: static PinScopeCardinality` (default `ccSingle` for the
+  ergonomic 0.7.x-style call shape). Completes the "Step 8" surface
+  widening flagged in `src/debra/types.nim` so callers can pass
+  `DebraManager[N, ccMulti]` to these procs without Nim's default-CC
+  rule triggering a `type mismatch`. The five wrappers infer `CC`
+  from the manager argument; `initDebraManager` keeps the default so
+  `initDebraManager[N]()` continues to return
+  `DebraManager[N, ccSingle]`, and `initDebraManager[N, ccMulti]()`
+  constructs the multi-cardinality variant directly.
 - `EpochGuardContext` typestate gained a `Closed` terminal state plus a
   `close` proc transitioning `Unpinned → Closed`. The full guard
   lifecycle is now `Pinned → Unpinned → Closed`. The new state is

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,12 +59,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - 60+ DR-T6 explicit-annotation sites widened across tests and examples
   to spell the new `CC` second parameter explicitly where the cardinality
   matters.
-- `AdvanceContext` remains intentionally CC-agnostic. The advance
-  protocol is pure atomic epoch arithmetic with no cardinality-dependent
-  branching; the operation is uniform across single- and multi-pin
-  scopes. Adding `CC` would be cargo-cult parameterization with zero
-  call-site benefit and a maintenance tax. Documented here so future
-  readers don't re-litigate the decision.
+- Five typestate context object types (`ReclaimContext`, `AdvanceContext`,
+  `ManagerContext`, `NeutralizeContext`, `SlotContext`) and their distinct
+  sub-states, typestate declarations, and builder procs gained
+  `CC: static PinScopeCardinality = ccSingle`, mirroring
+  `EpochGuardContext` / `RetireContext` / `PinnedScopeContext`. The
+  default `ccSingle` preserves the 0.7.x-style call shape; the parameter
+  enables ccMulti managers built by `initDebraManager[N, ccMulti]()` to
+  flow through the typestate context surface end-to-end, unblocking
+  multi-consumer reclamation paths in downstream lock-free clients
+  (e.g. `lockfreequeues` v5.0.0 multi-consumer pop body's `reclaimNow`
+  tail). This completes the Step 8 widening on the typestate context
+  layer that was missed in the manager-surface pass.
+  The `AdvanceContext` widening implements (rather than reverses) the
+  prior "intentionally CC-agnostic" intent: the advance ALGORITHM remains
+  uniform across cardinalities (pure atomic epoch arithmetic, no
+  CC-dependent branching), but the type system has to carry `CC` to accept
+  a `ptr DebraManager[MT, CC]` field for both cardinalities. The earlier
+  CHANGELOG entry asserting "no `CC` param on AdvanceContext" was based on
+  the algorithmic argument; the field type still defaulted to ccSingle and
+  rejected ccMulti managers at compile time. The ccSingle default preserves
+  the "no migration needed" contract for existing 0.7.x-style call shapes.
 - `typestates` dependency pinned at `>= 0.9.1` (downstream bracket-asymmetry
   fix exercised by the new `PinnedScope` and `EpochGuardContext` typestates;
   validated against 0.9.2).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-## [0.8.0] - YYYY-MM-DD
+## [0.8.0] - 2026-05-24
 
 ### Changed (breaking)
 
@@ -80,9 +80,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the algorithmic argument; the field type still defaulted to ccSingle and
   rejected ccMulti managers at compile time. The ccSingle default preserves
   the "no migration needed" contract for existing 0.7.x-style call shapes.
-- `typestates` dependency pinned at `>= 0.9.1` (downstream bracket-asymmetry
-  fix exercised by the new `PinnedScope` and `EpochGuardContext` typestates;
-  validated against 0.9.2).
+- `typestates` dependency pinned at `>= 0.9.3` (downstream bracket-asymmetry
+  fix exercised by the new `PinnedScope` and `EpochGuardContext` typestates).
+  The fix landed in the 0.9.2 dev cycle and shipped in released 0.9.3, which
+  consolidates the never-released 0.9.2 — so 0.9.3 is the lowest release that
+  carries it.
 - Test count: 210 → 229 (+19: 10 in `t_pinned_scope`, 9 in `t_retire_on_cas`).
 
 ## [0.7.3] - 2026-05-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,11 +80,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   the algorithmic argument; the field type still defaulted to ccSingle and
   rejected ccMulti managers at compile time. The ccSingle default preserves
   the "no migration needed" contract for existing 0.7.x-style call shapes.
-- `typestates` dependency pinned at `>= 0.9.3` (downstream bracket-asymmetry
-  fix exercised by the new `PinnedScope` and `EpochGuardContext` typestates).
-  The fix landed in the 0.9.2 dev cycle and shipped in released 0.9.3, which
-  consolidates the never-released 0.9.2 — so 0.9.3 is the lowest release that
-  carries it.
+- `typestates` dependency floor bumped to `>= 0.10.0`. 0.10.0 rewrote
+  `typestates verify` Pass 2 from a substring scanner to an AST classifier,
+  which correctly flags non-transition procs the old scanner silently
+  skipped. (Supersedes the prior `>= 0.9.3` pin for the bracket-asymmetry
+  fix exercised by `PinnedScope` / `EpochGuardContext`; 0.10.0 carries that
+  fix as well.)
+- 7 procs marked `{.notATransition.}` to satisfy the 0.10.0 AST verifier:
+  `retire` / `retireBatch` (`src/debra/convenience.nim`),
+  `retireReadyFromRetired` / `pinnedFromRetired`
+  (`src/debra/typestates/retire.nim`), `manager` accessors on the `Active`
+  and `Draining` states (`src/debra/typestates/slot.nim`), and `getManager`
+  (`src/debra/typestates/manager.nim`). An audit corrected an earlier
+  4-proc bot guess: `retireOnCAS` / `retireOnPublish` take a base context
+  type rather than a declared-state type and are correctly excluded.
 - Test count: 210 → 242 (per backend, across orc/arc/atomicArc/refc/cpp).
 
 ## [0.7.3] - 2026-05-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,7 +85,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   The fix landed in the 0.9.2 dev cycle and shipped in released 0.9.3, which
   consolidates the never-released 0.9.2 — so 0.9.3 is the lowest release that
   carries it.
-- Test count: 210 → 229 (+19: 10 in `t_pinned_scope`, 9 in `t_retire_on_cas`).
+- Test count: 210 → 242 (per backend, across orc/arc/atomicArc/refc/cpp).
 
 ## [0.7.3] - 2026-05-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,58 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - YYYY-MM-DD
+
+### Changed (breaking)
+
+- `withPin(handle): body` is deprecated. Replace with the `PinnedScope`
+  RAII type: `var scope = pinScope(unpinned(handle))`. The new form runs
+  unpin + close automatically at scope exit via `=destroy`. Removal is
+  targeted for 0.9.0; the deprecated `withPin` template still compiles
+  in 0.8.0 with a deprecation warning.
+- Nine typestate-axis types gained a second generic parameter
+  `CC: static PinScopeCardinality` (default `ccSingle`):
+  `ThreadHandle`, `Pinned`, `RetireReady`, `Unpinned`, `Neutralized`,
+  `Retired`, `Registered`, `DebraManager`, `PinnedScope`. The default
+  preserves source-compatibility for all single-cardinality call sites;
+  multi-pin patterns must opt in with explicit `[N, ccMulti]`.
+- `EpochGuardContext` typestate gained a `Closed` terminal state plus a
+  `close` proc transitioning `Unpinned → Closed`. The full guard
+  lifecycle is now `Pinned → Unpinned → Closed`. The new state is
+  exercised by `PinnedScope.=destroy`.
+
+### Added
+
+- `PinnedScope[MT, CC]` RAII type. `=destroy` automatically runs unpin
+  and close on scope exit, including on early-return / exception paths.
+- `pinScope(unpinned(handle))` constructor (verb-noun form, chosen to
+  avoid name collision with `guard.pin`).
+- `retireReady(scope.state)` retire chain, allowing `discard ready.retire(ptr, dtor)`
+  inside a `PinnedScope` without leaving the pinned axis.
+- `PinScopeCardinality` enum (`ccSingle`, `ccMulti`). `ccSingle` is the
+  safe default and matches single-PinnedScope-per-thread-per-lifetime
+  usage. `ccMulti` is an explicit opt-in for multi-pin patterns; see
+  the migration guide for the foot-gun callout (pin ordering and limbo
+  bag advancement become caller responsibilities).
+
+### Internal
+
+- 17 internal `withPin` call sites migrated to `PinnedScope` across
+  `src/debra/` and the test/example tree.
+- 60+ DR-T6 explicit-annotation sites widened across tests and examples
+  to spell the new `CC` second parameter explicitly where the cardinality
+  matters.
+- `AdvanceContext` remains intentionally CC-agnostic. The advance
+  protocol is pure atomic epoch arithmetic with no cardinality-dependent
+  branching; the operation is uniform across single- and multi-pin
+  scopes. Adding `CC` would be cargo-cult parameterization with zero
+  call-site benefit and a maintenance tax. Documented here so future
+  readers don't re-litigate the decision.
+- `typestates` dependency pinned at `>= 0.9.1` (downstream bracket-asymmetry
+  fix exercised by the new `PinnedScope` and `EpochGuardContext` typestates;
+  validated against 0.9.2).
+- Test count: 210 → 229 (+19: 10 in `t_pinned_scope`, 9 in `t_retire_on_cas`).
+
 ## [0.7.3] - 2026-05-08
 
 ### Fixed
@@ -348,7 +400,8 @@ type
 - Docs deployment workflow for GitHub Pages
 - Integration tests
 
-[Unreleased]: https://github.com/elijahr/nim-debra/compare/v0.7.3...HEAD
+[Unreleased]: https://github.com/elijahr/nim-debra/compare/v0.8.0...HEAD
+[0.8.0]: https://github.com/elijahr/nim-debra/compare/v0.7.3...v0.8.0
 [0.7.3]: https://github.com/elijahr/nim-debra/compare/v0.7.2...v0.7.3
 [0.7.2]: https://github.com/elijahr/nim-debra/compare/v0.7.1...v0.7.2
 [0.7.1]: https://github.com/elijahr/nim-debra/compare/v0.7.0...v0.7.1

--- a/debra.nimble
+++ b/debra.nimble
@@ -12,7 +12,7 @@ installExt = @["nim"]
 # Dependencies
 
 requires "nim >= 2.2.10"
-requires "typestates >= 0.9.3"
+requires "typestates >= 0.10.0"
 requires "unittest2 >= 0.2.0"
 
 # Tasks

--- a/debra.nimble
+++ b/debra.nimble
@@ -31,6 +31,9 @@ task test, "Run tests with all memory managers":
   echo "[nim check] verifying tests/t_atomics_dsl_negative.nim - DSL must NOT leak into debra/atomics core"
   exec "nim check --threads:on --hints:off --warnings:off --path:src tests/t_atomics_dsl_negative.nim"
   echo "[nim check] passed: DSL boundary intact"
+  echo "[should_fail] verifying compile-fail tests for PinnedScope + CFG analyzer"
+  exec "nim r --hints:off --warnings:off --path:src tests/should_fail/runner.nim"
+  echo "[should_fail] passed: PinnedScope =copy + CFG-terminal substrings pinned"
   echo "All backends passed!"
 
 task testExamples, "Compile and run all example files":

--- a/debra.nimble
+++ b/debra.nimble
@@ -12,7 +12,7 @@ installExt = @["nim"]
 # Dependencies
 
 requires "nim >= 2.2.10"
-requires "typestates >= 0.9.1"
+requires "typestates >= 0.9.3"
 requires "unittest2 >= 0.2.0"
 
 # Tasks

--- a/debra.nimble
+++ b/debra.nimble
@@ -2,7 +2,7 @@
 
 # Package
 
-version = "0.7.3"
+version = "0.8.0"
 author = "elijahr <elijahr+debra@gmail.com>"
 description = "DEBRA+ safe memory reclamation for lock-free data structures"
 license = "MIT"

--- a/debra.nimble
+++ b/debra.nimble
@@ -12,7 +12,7 @@ installExt = @["nim"]
 # Dependencies
 
 requires "nim >= 2.2.10"
-requires "typestates >= 0.7.1"
+requires "typestates >= 0.9.1"
 requires "unittest2 >= 0.2.0"
 
 # Tasks

--- a/docs/MIGRATION_v0.8.0.md
+++ b/docs/MIGRATION_v0.8.0.md
@@ -92,12 +92,13 @@ ordering and advance interaction.
 
 ## AdvanceContext
 
-**No migration needed.** `AdvanceContext` remains CC-agnostic. The
-epoch advancement protocol is cardinality-uniform — pure atomic
-arithmetic with no cardinality-dependent branching — so widening
-`AdvanceContext` with the `CC` parameter would be cargo-cult and add
-zero call-site benefit. Annotations on `AdvanceContext` values do not
-need to be updated.
+**No migration needed.** `AdvanceContext` gained the `CC` parameter — its
+field must accept a `ptr DebraManager[MT, CC]` for both cardinalities — but
+the epoch advancement protocol itself is cardinality-uniform: pure atomic
+arithmetic with no cardinality-dependent branching. Because `CC` defaults to
+`ccSingle`, existing annotations on `AdvanceContext` values do not need to be
+updated; `ccMulti` managers flow through automatically when constructed via
+`initDebraManager[N, ccMulti]()`.
 
 ## Deprecation timeline
 
@@ -116,5 +117,5 @@ nim-debra 0.8.0 itself migrated 17 internal `withPin` call sites to
 `PinnedScope` across the source tree, plus 60+ DR-T6 explicit-annotation
 sites widened to spell the `CC` second parameter. This is the same
 translation the migration guide prescribes — proof the pattern works
-end-to-end and is exercised by the 229-test suite across all five
+end-to-end and is exercised by the 242-test suite across all five
 backends (orc, arc, atomicArc, refc, cpp).

--- a/docs/MIGRATION_v0.8.0.md
+++ b/docs/MIGRATION_v0.8.0.md
@@ -1,0 +1,120 @@
+# Migration Guide: nim-debra 0.8.0
+
+## Audience
+
+Users with code calling `withPin(handle): body` (anonymous form) or
+`withPin(handle, named): body` (named-overload form). `withPin` is
+deprecated in 0.8.0 and targeted for removal in 0.9.0; new code should
+use `PinnedScope`.
+
+If your code does not call `withPin` and you do not annotate
+`ThreadHandle`/`Pinned`/`Unpinned`/`Retired`/`Neutralized`/`Registered`/
+`DebraManager`/`RetireReady`/`PinnedScope` types explicitly, the
+0.7.x → 0.8.0 upgrade should be source-compatible thanks to the
+`ccSingle` default on the new `CC` generic parameter.
+
+## Mechanical translation
+
+### Anonymous form (`withPin(handle): body`)
+
+```nim
+# Before (0.7.x):
+withPin(handle):
+  # body referencing `it: Pinned[N]`
+  let r = retire(it, ptr, dtor)
+
+# After (0.8.0):
+block:
+  var scope = pinScope(unpinned(handle))
+  var ready = retireReady(scope.state)
+  discard ready.retire(ptr, dtor)
+  # =destroy auto-runs unpin + close at block exit
+```
+
+Key changes:
+
+- `withPin` is replaced by `pinScope(unpinned(handle))`, which returns a
+  `PinnedScope[N, ccSingle]` value bound to `scope`.
+- The implicit `it` binding is replaced by `scope.state` (a `Pinned[N]`
+  on the pinned axis).
+- `retire` is reached through the explicit `retireReady` chain rather
+  than as a free proc on `it`.
+- Unpin and close happen automatically via `=destroy` when `scope` goes
+  out of scope, including on early-return and exception paths. No
+  explicit cleanup is required.
+
+### Named-overload form (`withPin(handle, named): body`)
+
+```nim
+# Before (0.7.x):
+withPin(handle, myPin):
+  # body referencing `myPin: Pinned[N]`
+  let r = retire(myPin, ptr, dtor)
+
+# After (0.8.0):
+block:
+  var myPin = pinScope(unpinned(handle))
+  var ready = retireReady(myPin.state)
+  discard ready.retire(ptr, dtor)
+  # =destroy auto-runs unpin + close at block exit
+```
+
+The named binding becomes the `PinnedScope` value itself; reach the
+underlying `Pinned[N]` via `myPin.state`.
+
+## Cardinality opt-in (`PinScopeCardinality`)
+
+0.8.0 introduces the `PinScopeCardinality` enum on the second generic
+parameter (`CC`) of nine typestate-axis types:
+
+- `ccSingle` (**default, safe**): single `PinnedScope` per thread per
+  lifetime. The compiler enforces single-pin discipline; the runtime
+  invariants match the 0.7.x single-`withPin`-at-a-time model.
+- `ccMulti` (**opt-in, advanced**): multi-pin patterns are permitted on
+  this axis. Selected explicitly via `[N, ccMulti]` on the type
+  annotation.
+
+### Foot-gun callout for `ccMulti`
+
+`ccMulti` is **not** "use this if you're not sure." It is an explicit
+opt-in for advanced patterns. When you opt in, you take on:
+
+- Explicit reasoning about pin ordering — nested `PinnedScope` lifetimes
+  must form a stack, not an arbitrary DAG, or you risk reading from a
+  retired bag.
+- Explicit reasoning about limbo-bag advancement — concurrent multi-pin
+  scopes can stall epoch advancement if their lifetimes overlap with
+  the manager's advance protocol in unexpected ways.
+
+`ccSingle` is the right default. Reach for `ccMulti` only when you have
+a concrete pattern that demands it and you have audited the pin
+ordering and advance interaction.
+
+## AdvanceContext
+
+**No migration needed.** `AdvanceContext` remains CC-agnostic. The
+epoch advancement protocol is cardinality-uniform — pure atomic
+arithmetic with no cardinality-dependent branching — so widening
+`AdvanceContext` with the `CC` parameter would be cargo-cult and add
+zero call-site benefit. Annotations on `AdvanceContext` values do not
+need to be updated.
+
+## Deprecation timeline
+
+| Version | `withPin` status |
+| ------- | ---------------- |
+| 0.8.0   | Deprecated, still works, emits deprecation warning. |
+| 0.9.0   | Planned removal. New code MUST use `PinnedScope`. |
+
+There is no flag to silence the deprecation warning in 0.8.0; the
+intent is to make the migration visible at every call site so the
+0.9.0 removal is a no-op for downstream code.
+
+## Self-evidence
+
+nim-debra 0.8.0 itself migrated 17 internal `withPin` call sites to
+`PinnedScope` across the source tree, plus 60+ DR-T6 explicit-annotation
+sites widened to spell the `CC` second parameter. This is the same
+translation the migration guide prescribes — proof the pattern works
+end-to-end and is exercised by the 229-test suite across all five
+backends (orc, arc, atomicArc, refc, cpp).

--- a/examples/basic_usage.nim
+++ b/examples/basic_usage.nim
@@ -11,7 +11,7 @@ type
   Node = ref NodeObj
 
 # One pin/retire/unpin cycle.
-proc doCycle(handle: ThreadHandle[4], value: int) =
+proc doCycle(handle: ThreadHandle[4, ccSingle], value: int) =
   let u = unpinned(handle)
   let pinned = u.pin()
 

--- a/examples/lockfree_queue.nim
+++ b/examples/lockfree_queue.nim
@@ -21,10 +21,10 @@ type
   Queue*[T] = object
     head: Atomic[ptr NodeObj[T]]
     tail: Atomic[ptr NodeObj[T]]
-    manager: ptr DebraManager[64]
+    manager: ptr DebraManager[64, ccSingle]
     handle: ThreadHandle[64, ccSingle]
 
-proc newQueue*[T](manager: ptr DebraManager[64]): Queue[T] =
+proc newQueue*[T](manager: ptr DebraManager[64, ccSingle]): Queue[T] =
   result.manager = manager
   result.handle = registerThread(manager[])
 

--- a/examples/lockfree_queue.nim
+++ b/examples/lockfree_queue.nim
@@ -22,7 +22,7 @@ type
     head: Atomic[ptr NodeObj[T]]
     tail: Atomic[ptr NodeObj[T]]
     manager: ptr DebraManager[64]
-    handle: ThreadHandle[64]
+    handle: ThreadHandle[64, ccSingle]
 
 proc newQueue*[T](manager: ptr DebraManager[64]): Queue[T] =
   result.manager = manager
@@ -38,7 +38,8 @@ proc newQueue*[T](manager: ptr DebraManager[64]): Queue[T] =
 proc enqueue*[T](queue: var Queue[T], value: T) =
   let newNode = retain Node[T](value: value)
 
-  queue.handle.withPin:
+  block:
+    var scope {.used.} = pinScope(unpinned(queue.handle))
     while true:
       let tail = queue.tail.load(moAcquire)
       let next = tail.next.load(moAcquire)
@@ -64,7 +65,9 @@ proc enqueue*[T](queue: var Queue[T], value: T) =
 proc dequeue*[T](queue: var Queue[T]): Option[T] =
   result = none(T)
 
-  queue.handle.withPin:
+  block:
+    var scope = pinScope(unpinned(queue.handle))
+    var ready = retireReady(scope.state)
     block dequeueLoop:
       while true:
         let head = queue.head.load(moAcquire)
@@ -86,7 +89,7 @@ proc dequeue*[T](queue: var Queue[T]): Option[T] =
             # Retire old head (sentinel). The destructor will GC_unref it
             # once the epoch is safe, balancing the `retain` from newQueue
             # or the previous enqueue.
-            it.retire(cast[pointer](head), releaseDestructor[NodeObj[T]]())
+            ready.retire(cast[pointer](head), releaseDestructor[NodeObj[T]]())
             result = some(value)
             break dequeueLoop
 

--- a/examples/lockfree_stack.nim
+++ b/examples/lockfree_stack.nim
@@ -21,7 +21,7 @@ type
   Stack*[T] = object
     head: Atomic[ptr NodeObj[T]]
     manager: ptr DebraManager[64]
-    handle: ThreadHandle[64]
+    handle: ThreadHandle[64, ccSingle]
 
 proc newStack*[T](manager: ptr DebraManager[64]): Stack[T] =
   result.manager = manager
@@ -30,7 +30,8 @@ proc newStack*[T](manager: ptr DebraManager[64]): Stack[T] =
 proc push*[T](stack: var Stack[T], value: T) =
   let newNode = retain Node[T](value: value)
 
-  stack.handle.withPin:
+  block:
+    var scope {.used.} = pinScope(unpinned(stack.handle))
     while true:
       let oldHead = stack.head.load(moAcquire)
       newNode.next.store(oldHead, moRelaxed)
@@ -41,7 +42,9 @@ proc push*[T](stack: var Stack[T], value: T) =
 proc pop*[T](stack: var Stack[T]): Option[T] =
   result = none(T)
 
-  stack.handle.withPin:
+  block:
+    var scope = pinScope(unpinned(stack.handle))
+    var ready = retireReady(scope.state)
     block popLoop:
       while true:
         let oldHead = stack.head.load(moAcquire)
@@ -54,7 +57,7 @@ proc pop*[T](stack: var Stack[T]): Option[T] =
           result = some(oldHead.value)
           # Retire the popped node. The destructor balances the `retain`
           # done by `push` once the epoch is safe.
-          it.retire(cast[pointer](oldHead), releaseDestructor[NodeObj[T]]())
+          ready.retire(cast[pointer](oldHead), releaseDestructor[NodeObj[T]]())
           break popLoop
 
 proc main() =

--- a/examples/lockfree_stack.nim
+++ b/examples/lockfree_stack.nim
@@ -20,10 +20,10 @@ type
 
   Stack*[T] = object
     head: Atomic[ptr NodeObj[T]]
-    manager: ptr DebraManager[64]
+    manager: ptr DebraManager[64, ccSingle]
     handle: ThreadHandle[64, ccSingle]
 
-proc newStack*[T](manager: ptr DebraManager[64]): Stack[T] =
+proc newStack*[T](manager: ptr DebraManager[64, ccSingle]): Stack[T] =
   result.manager = manager
   result.handle = registerThread(manager[])
 

--- a/examples/lockfree_stack_typestates.nim
+++ b/examples/lockfree_stack_typestates.nim
@@ -30,7 +30,7 @@ type
   StackBase[T] = object
     top: Atomic[ptr NodeObj[T]]
     manager: ptr DebraManager[64]
-    handle: ThreadHandle[64]
+    handle: ThreadHandle[64, ccSingle]
 
   Empty*[T] = distinct StackBase[T] ## Stack with no elements.
 

--- a/examples/lockfree_stack_typestates.nim
+++ b/examples/lockfree_stack_typestates.nim
@@ -29,7 +29,7 @@ type
 
   StackBase[T] = object
     top: Atomic[ptr NodeObj[T]]
-    manager: ptr DebraManager[64]
+    manager: ptr DebraManager[64, ccSingle]
     handle: ThreadHandle[64, ccSingle]
 
   Empty*[T] = distinct StackBase[T] ## Stack with no elements.
@@ -43,7 +43,7 @@ typestate StackBase[T]:
     Empty[T] -> NonEmpty[T]
     NonEmpty[T] -> Empty[T] | NonEmpty[T] as PopResult[T]
 
-proc initStack*[T](manager: ptr DebraManager[64]): Empty[T] =
+proc initStack*[T](manager: ptr DebraManager[64, ccSingle]): Empty[T] =
   ## Create a new empty stack.
   var base: StackBase[T]
   base.manager = manager

--- a/examples/pin_unpin.nim
+++ b/examples/pin_unpin.nim
@@ -30,18 +30,22 @@ proc main() =
       echo "Was neutralized - acknowledging"
       discard unpinResult.neutralized.acknowledge()
 
-  # Multiple pin/retire/unpin cycles using the high-level `withPin` sugar.
-  # `withPin` injects `it: var RetireReady[MT]` and unpins on scope exit
-  # (including raises). `retain` GC-pins the ref; `releaseDestructor` is
-  # the matching destructor that runs at reclamation time.
+  # Multiple pin/retire/unpin cycles using the PinnedScope RAII guard.
+  # `pinScope(unpinned(handle))` opens a scope whose `=destroy` unpins on
+  # block exit (including raises). `retireReady(scope.state)` projects the
+  # inner `Pinned` to a `RetireReady` we can retire through; `retain`
+  # GC-pins the ref; `releaseDestructor` is the matching destructor that
+  # runs at reclamation time.
   echo ""
-  echo "=== Multiple Cycles (withPin) ==="
+  echo "=== Multiple Cycles (PinnedScope) ==="
   let dtor = releaseDestructor[NodeObj]()
   for i in 1 .. 3:
-    handle.withPin:
+    block:
+      var scope = pinScope(unpinned(handle))
+      var ready = retireReady(scope.state)
       echo "Cycle ", i, ": pinned"
       let node = retain Node(value: i * 100)
-      it.retire(cast[pointer](node), dtor)
+      ready.retire(cast[pointer](node), dtor)
 
     # Advance epoch between cycles so reclamation can make progress.
     manager.advance()

--- a/examples/reclamation_background.nim
+++ b/examples/reclamation_background.nim
@@ -46,7 +46,7 @@ else:
     Node = ref NodeObj
 
   var
-    manager: DebraManager[4]
+    manager: DebraManager[4, ccSingle]
     shouldStop: Atomic[bool]
     totalReclaimed: Atomic[int]
 

--- a/examples/reclamation_background.nim
+++ b/examples/reclamation_background.nim
@@ -68,9 +68,11 @@ else:
       let dtor = releaseDestructor[NodeObj]()
 
       for i in 0 ..< 100:
-        withPin(handle):
+        block:
+          var scope = pinScope(unpinned(handle))
+          var ready = retireReady(scope.state)
           let node = retain Node(value: i)
-          it.retire(cast[pointer](node), dtor)
+          ready.retire(cast[pointer](node), dtor)
 
         # Reclaim our own bag occasionally. The background thread keeps the
         # global epoch advancing, so most of these passes find work.

--- a/examples/reclamation_periodic.nim
+++ b/examples/reclamation_periodic.nim
@@ -11,10 +11,12 @@ type
 
 const ReclaimInterval = 10
 
-proc doOperation(handle: ThreadHandle[64], dtor: Destructor, i: int) =
-  handle.withPin:
+proc doOperation(handle: ThreadHandle[64, ccSingle], dtor: Destructor, i: int) =
+  block:
+    var scope = pinScope(unpinned(handle))
+    var ready = retireReady(scope.state)
     let node = retain Node(value: i)
-    it.retire(cast[pointer](node), dtor)
+    ready.retire(cast[pointer](node), dtor)
 
 proc periodicReclaimDemo() =
   var manager = initDebraManager[64]()

--- a/examples/retire_multiple.nim
+++ b/examples/retire_multiple.nim
@@ -3,7 +3,8 @@
 ##
 ## Demonstrates chaining retires by threading `RetireReady` through
 ## `retireReadyFromRetired`, which is the lower-level form behind the
-## `var RetireReady` overload used by `withPin` bodies.
+## `var RetireReady` overload typically consumed inside a `PinnedScope`
+## via `retireReady(scope.state)`.
 
 import debra
 
@@ -38,9 +39,10 @@ proc main() =
   echo "Retired 5 nodes"
 
   # Rebuild the Pinned context from the last RetireReady so we can unpin.
-  let ctx = RetireContext[4](ready)
-  let pinnedAgain =
-    Pinned[4](EpochGuardContext[4](handle: ctx.handle, epoch: ctx.epoch))
+  let ctx = RetireContext[4, ccSingle](ready)
+  let pinnedAgain = Pinned[4, ccSingle](
+    EpochGuardContext[4, ccSingle](handle: ctx.handle, epoch: ctx.epoch)
+  )
   discard pinnedAgain.unpin()
 
   echo "Multiple retirement example completed"

--- a/examples/thread_registration.nim
+++ b/examples/thread_registration.nim
@@ -4,7 +4,7 @@
 import debra
 import debra/atomics
 
-var manager: DebraManager[4]
+var manager: DebraManager[4, ccSingle]
 
 proc workerThread() {.thread.} =
   # Register this thread with the manager

--- a/src/debra.nim
+++ b/src/debra.nim
@@ -17,6 +17,7 @@ import ./debra/typestates/manager
 import ./debra/typestates/registration
 import ./debra/typestates/guard
 import ./debra/typestates/retire
+import ./debra/typestates/pinned_scope
 import ./debra/typestates/reclaim
 import ./debra/typestates/neutralize
 import ./debra/typestates/advance
@@ -34,6 +35,7 @@ export manager
 export registration
 export guard
 export retire
+export pinned_scope
 export reclaim
 export neutralize
 export advance

--- a/src/debra.nim
+++ b/src/debra.nim
@@ -11,6 +11,7 @@ import ./debra/types
 import ./debra/signal
 import ./debra/limbo
 import ./debra/thread_id
+import ./debra/typestates/cardinality
 import ./debra/typestates/signal_handler
 import ./debra/typestates/manager
 import ./debra/typestates/registration
@@ -27,6 +28,7 @@ export types
 export signal.setGlobalManager, signal.installSignalHandler
 export limbo
 export thread_id
+export cardinality
 export signal_handler
 export manager
 export registration
@@ -39,13 +41,17 @@ export slot
 export refptr
 export convenience
 
-proc registerThread*[MaxThreads: static int](
-    manager: var DebraManager[MaxThreads]
-): ThreadHandle[MaxThreads] {.raises: [DebraRegistrationError].} =
+proc registerThread*[MaxThreads: static int, CC: static PinScopeCardinality](
+    manager: var DebraManager[MaxThreads, CC]
+): ThreadHandle[MaxThreads, CC] {.raises: [DebraRegistrationError].} =
   ## Register current thread with the DEBRA manager.
   ##
   ## Must be called once per thread before any epoch operations.
   ## Raises DebraRegistrationError if max threads already registered.
+  ##
+  ## The `CC` parameter binds via the `manager` argument, so callers
+  ## that pass `DebraManager[N]` (which defaults `CC = ccSingle`)
+  ## receive `ThreadHandle[N, ccSingle]` unchanged from 0.7.x.
   installSignalHandler()
 
   let u = unregistered(addr manager)

--- a/src/debra.nim
+++ b/src/debra.nim
@@ -76,20 +76,28 @@ proc neutralizeStalled*[MaxThreads: static int](
   let complete = scanning.scanAndSignal()
   complete.extractSignalCount()
 
-proc advance*[MaxThreads: static int](
-    manager: var DebraManager[MaxThreads]
+proc advance*[MaxThreads: static int, CC: static PinScopeCardinality = ccSingle](
+    manager: var DebraManager[MaxThreads, CC]
 ) {.inline.} =
   ## Advance the global epoch.
+  ##
+  ## The `CC` parameter binds via the `manager` argument; callers that
+  ## pass `DebraManager[N]` (CC default `ccSingle`) keep the 0.7.x call
+  ## shape, while `DebraManager[N, ccMulti]` is also accepted.
   discard manager.globalEpoch.fetchAdd(1'u64, moRelease)
 
-proc currentEpoch*[MaxThreads: static int](
-    manager: var DebraManager[MaxThreads]
+proc currentEpoch*[MaxThreads: static int, CC: static PinScopeCardinality = ccSingle](
+    manager: var DebraManager[MaxThreads, CC]
 ): uint64 {.inline.} =
   ## Get current global epoch.
+  ##
+  ## The `CC` parameter binds via the `manager` argument; callers that
+  ## pass `DebraManager[N]` (CC default `ccSingle`) keep the 0.7.x call
+  ## shape, while `DebraManager[N, ccMulti]` is also accepted.
   manager.globalEpoch.load(moAcquire)
 
-proc bindClient*[MaxThreads: static int](
-    manager: var DebraManager[MaxThreads]
+proc bindClient*[MaxThreads: static int, CC: static PinScopeCardinality = ccSingle](
+    manager: var DebraManager[MaxThreads, CC]
 ) {.inline.} =
   ## Register a client (e.g. a lock-free data structure) as bound to
   ## this manager. Increments `boundClients` by 1.
@@ -99,10 +107,14 @@ proc bindClient*[MaxThreads: static int](
   ## manager's destructor asserts the count is zero, so a non-zero
   ## count at teardown means a client outlived its manager: the client
   ## would continue calling into freed manager state.
+  ##
+  ## The `CC` parameter binds via the `manager` argument; callers that
+  ## pass `DebraManager[N]` (CC default `ccSingle`) keep the 0.7.x call
+  ## shape, while `DebraManager[N, ccMulti]` is also accepted.
   discard manager.boundClients.fetchAdd(1, moAcquireRelease)
 
-proc unbindClient*[MaxThreads: static int](
-    manager: var DebraManager[MaxThreads]
+proc unbindClient*[MaxThreads: static int, CC: static PinScopeCardinality = ccSingle](
+    manager: var DebraManager[MaxThreads, CC]
 ) {.inline.} =
   ## Unregister a client previously bound via `bindClient`. Decrements
   ## `boundClients` by 1. See `bindClient` for usage.
@@ -111,15 +123,23 @@ proc unbindClient*[MaxThreads: static int](
   ## unbalanced unbind (e.g. double-destroy of a client) and is caught
   ## here with a precise stack trace, rather than later as a non-zero
   ## value seen by the manager destructor.
+  ##
+  ## The `CC` parameter binds via the `manager` argument; callers that
+  ## pass `DebraManager[N]` (CC default `ccSingle`) keep the 0.7.x call
+  ## shape, while `DebraManager[N, ccMulti]` is also accepted.
   let prev = manager.boundClients.fetchSub(1, moAcquireRelease)
   doAssert prev > 0,
     "unbindClient: boundClients underflow (was " & $prev &
       ", expected > 0); unbalanced bindClient/unbindClient"
 
-proc clientCount*[MaxThreads: static int](
-    manager: var DebraManager[MaxThreads]
+proc clientCount*[MaxThreads: static int, CC: static PinScopeCardinality = ccSingle](
+    manager: var DebraManager[MaxThreads, CC]
 ): int {.inline.} =
   ## Number of clients currently bound to this manager. Relaxed load,
   ## suitable for inspection and tests; not synchronized against
   ## concurrent `bindClient` / `unbindClient`.
+  ##
+  ## The `CC` parameter binds via the `manager` argument; callers that
+  ## pass `DebraManager[N]` (CC default `ccSingle`) keep the 0.7.x call
+  ## shape, while `DebraManager[N, ccMulti]` is also accepted.
   manager.boundClients.load(moRelaxed)

--- a/src/debra/convenience.nim
+++ b/src/debra/convenience.nim
@@ -59,8 +59,8 @@ import ./typestates/reclaim
 # Batched retire/reclaim API (see docs/design/2026-04-25-batched-retire-reclaim.md)
 # ---------------------------------------------------------------------------
 
-proc retire*[MT: static int](
-    pin: var RetireReady[MT], p: pointer, destructor: Destructor
+proc retire*[MT: static int, CC: static PinScopeCardinality = ccSingle](
+    pin: var RetireReady[MT, CC], p: pointer, destructor: Destructor
 ) =
   ## Retire `p` inside an existing pinned epoch held by `pin`.
   ##
@@ -75,19 +75,21 @@ proc retire*[MT: static int](
     var manager = initDebraManager[4]()
     setGlobalManager(addr manager)
     let handle = registerThread(manager)
-    withPin(handle):
+    block:
+      var scope = pinScope(unpinned(handle))
+      var ready = retireReady(scope.state)
       let p = alloc0(8)
-      it.retire(p, dtor)
+      discard ready.retire(p, dtor)
   let retired = retire(move(pin), p, destructor)
   pin = retireReadyFromRetired(retired)
 
-proc retireBatch*[MT: static int](
-    pin: var RetireReady[MT], items: openArray[(pointer, Destructor)]
+proc retireBatch*[MT: static int, CC: static PinScopeCardinality = ccSingle](
+    pin: var RetireReady[MT, CC], items: openArray[(pointer, Destructor)]
 ) =
   ## Retire each `(p, dtor)` in `items` inside an existing pinned epoch.
   ##
   ## Must be called from within `withPin` body (or any other holder of a
-  ## `var RetireReady[MT]`). No pinning, no reclamation. Avoids one
+  ## `var RetireReady[MT, CC]`). No pinning, no reclamation. Avoids one
   ## pin/unpin per object when freeing chains.
   runnableExamples:
     import debra
@@ -99,15 +101,22 @@ proc retireBatch*[MT: static int](
     let handle = registerThread(manager)
     let a = alloc0(8)
     let b = alloc0(8)
-    withPin(handle):
-      it.retireBatch([(a, dtor), (b, dtor)])
+    block:
+      var scope = pinScope(unpinned(handle))
+      var ready = retireReady(scope.state)
+      ready.retireBatch([(a, dtor), (b, dtor)])
   for item in items:
     pin.retire(item[0], item[1])
 
-template withPin*[MT: static int](th: ThreadHandle[MT], body: untyped) =
+template withPin*[MT: static int, CC: static PinScopeCardinality = ccSingle](
+    th: ThreadHandle[MT, CC], body: untyped
+) {.
+    deprecated:
+      "use PinnedScope: var scope = pinScope(unpinned(handle)); see CHANGELOG.md#v0.8.0"
+.} =
   ## Pin the calling thread, run `body`, unpin on exit (including raises).
   ##
-  ## Injects `it` as a `var RetireReady[MT]` (matches the Nim convention
+  ## Injects `it` as a `var RetireReady[MT, CC]` (matches the Nim convention
   ## used by `filterIt`/`mapIt`). Body may call `it.retire(p, dtor)` zero
   ## or more times. Using `it` avoids collisions with the exported `pin`
   ## proc from `debra/typestates/guard`.
@@ -138,6 +147,7 @@ template withPin*[MT: static int](th: ThreadHandle[MT], body: untyped) =
   ## See also: `debra/typestates/guard.pin`_ (explicit transition), `retire`_,
   ## `retireBatch`_, `debra/typestates/neutralize.neutralizeStalled`_.
   runnableExamples:
+    {.push warning[Deprecated]: off.}
     import debra
     proc dtor(p: pointer) {.nimcall.} =
       dealloc(p)
@@ -148,6 +158,7 @@ template withPin*[MT: static int](th: ThreadHandle[MT], body: untyped) =
     withPin(handle):
       let p = alloc0(8)
       it.retire(p, dtor)
+    {.pop.}
   block:
     let h = th
     doAssert not h.manager.threads[h.idx].pinned.load(moAcquire),
@@ -169,7 +180,12 @@ template withPin*[MT: static int](th: ThreadHandle[MT], body: untyped) =
         Neutralized(nval):
           discard nval.acknowledge()
 
-template withPin*[MT: static int](th: ThreadHandle[MT], name, body: untyped) =
+template withPin*[MT: static int, CC: static PinScopeCardinality = ccSingle](
+    th: ThreadHandle[MT, CC], name, body: untyped
+) {.
+    deprecated:
+      "use PinnedScope: var scope = pinScope(unpinned(handle)); see CHANGELOG.md#v0.8.0"
+.} =
   ## `withPin` variant that injects a caller-supplied identifier `name`
   ## (instead of the default `it`). Use to disambiguate nested handles
   ## across multiple managers. The neutralization pitfall described on
@@ -177,6 +193,7 @@ template withPin*[MT: static int](th: ThreadHandle[MT], name, body: untyped) =
   ## docstring before relying on this form for code paths that may be
   ## interrupted by `neutralizeStalled`.
   runnableExamples:
+    {.push warning[Deprecated]: off.}
     import debra
     proc dtor(p: pointer) {.nimcall.} =
       dealloc(p)
@@ -187,6 +204,7 @@ template withPin*[MT: static int](th: ThreadHandle[MT], name, body: untyped) =
     withPin(handle, slot):
       let p = alloc0(8)
       slot.retire(p, dtor)
+    {.pop.}
   block:
     let h = th
     doAssert not h.manager.threads[h.idx].pinned.load(moAcquire),
@@ -206,8 +224,8 @@ template withPin*[MT: static int](th: ThreadHandle[MT], name, body: untyped) =
         Neutralized(nval):
           discard nval.acknowledge()
 
-proc advanceEvery*[MT: static int](
-    handle: ThreadHandle[MT], n: static int
+proc advanceEvery*[MT: static int, CC: static PinScopeCardinality = ccSingle](
+    handle: ThreadHandle[MT, CC], n: static int
 ): bool {.discardable.} =
   ## Increment a per-handle counter; advance the global epoch once every
   ## `n` calls. Returns `true` on the calls that actually advanced.
@@ -244,8 +262,10 @@ proc advanceEvery*[MT: static int](
     let handle = registerThread(manager)
     # Hot loop: retire and amortize the global-epoch atomic store.
     for i in 0 ..< 100:
-      withPin(handle):
-        it.retire(alloc0(8), dtor)
+      block:
+        var scope = pinScope(unpinned(handle))
+        var ready = retireReady(scope.state)
+        discard ready.retire(alloc0(8), dtor)
       handle.advanceEvery(32)
     discard reclaimNow(manager)
   static:
@@ -257,7 +277,9 @@ proc advanceEvery*[MT: static int](
     return true
   return false
 
-proc reclaimNow*[MT: static int](handle: ThreadHandle[MT]): int =
+proc reclaimNow*[MT: static int, CC: static PinScopeCardinality = ccSingle](
+    handle: ThreadHandle[MT, CC]
+): int =
   ## Run one reclamation pass over the calling thread's own retired objects.
   ## Returns the number of objects reclaimed, or 0 if no epoch is currently
   ## safe to reclaim.
@@ -279,8 +301,10 @@ proc reclaimNow*[MT: static int](handle: ThreadHandle[MT]): int =
     # Brand-new manager: no retired objects, returns 0 (not an error).
     doAssert reclaimNow(handle) == 0
     # Retire something, advance the epoch a few times, then reclaim.
-    withPin(handle):
-      it.retire(alloc0(8), dtor)
+    block:
+      var scope = pinScope(unpinned(handle))
+      var ready = retireReady(scope.state)
+      discard ready.retire(alloc0(8), dtor)
     manager.advance()
     manager.advance()
     discard reclaimNow(handle)
@@ -302,8 +326,8 @@ proc reclaimNow*[MT: static int](manager: var DebraManager[MT]): int =
   else:
     0
 
-proc retireAndReclaim*[MT: static int](
-    handle: ThreadHandle[MT], p: pointer, destructor: Destructor, eager: bool = true
+proc retireAndReclaim*[MT: static int, CC: static PinScopeCardinality = ccSingle](
+    handle: ThreadHandle[MT, CC], p: pointer, destructor: Destructor, eager: bool = true
 ) =
   ## Retire a pointer and optionally attempt immediate reclamation.
   ##
@@ -334,9 +358,9 @@ proc retireAndReclaim*[MT: static int](
   let retired = ready.retire(p, destructor)
 
   # Convert Retired back to Pinned for unpinning
-  let ctx = RetireContext[MT](retired)
+  let ctx = RetireContext[MT, CC](retired)
   let pinnedAgain =
-    Pinned[MT](EpochGuardContext[MT](handle: ctx.handle, epoch: ctx.epoch))
+    Pinned[MT, CC](EpochGuardContext[MT, CC](handle: ctx.handle, epoch: ctx.epoch))
   discard pinnedAgain.unpin()
 
   # Optional eager reclamation (per-thread, scoped to this handle's slot).

--- a/src/debra/convenience.nim
+++ b/src/debra/convenience.nim
@@ -320,10 +320,16 @@ proc reclaimNow*[MT: static int, CC: static PinScopeCardinality = ccSingle](
   else:
     0
 
-proc reclaimNow*[MT: static int](manager: var DebraManager[MT]): int =
+proc reclaimNow*[MT: static int, CC: static PinScopeCardinality = ccSingle](
+    manager: var DebraManager[MT, CC]
+): int =
   ## Legacy wrapper: infers the calling thread's slot from `threadLocalIdx`
   ## (set by `registerThread`). Prefer `reclaimNow(handle)` for clarity and
   ## for safety from unregistered threads.
+  ##
+  ## The `CC` parameter binds via the `manager` argument; callers that pass
+  ## `DebraManager[N]` (CC default `ccSingle`) keep the 0.7.x call shape,
+  ## while `DebraManager[N, ccMulti]` is also accepted.
   ##
   ## See also: `debra/typestates/reclaim.tryReclaim`_, `advance`_.
   let op = reclaimStart(addr manager).loadEpochs().checkSafe()

--- a/src/debra/convenience.nim
+++ b/src/debra/convenience.nim
@@ -114,7 +114,8 @@ proc retireBatch*[MT: static int, CC: static PinScopeCardinality = ccSingle](
       var ready = retireReady(scope.state)
       ready.retireBatch([(a, dtor), (b, dtor)])
   for item in items:
-    pin.retire(item[0], item[1])
+    if item[0] != nil:
+      pin.retire(item[0], item[1])
 
 template withPin*[MT: static int, CC: static PinScopeCardinality = ccSingle](
     th: ThreadHandle[MT, CC], body: untyped

--- a/src/debra/convenience.nim
+++ b/src/debra/convenience.nim
@@ -5,19 +5,22 @@
 ##
 ## ## Pitfalls
 ##
-## * `withPin` does not allow re-pinning the same handle inside its body.
-##   A `doAssert` catches direct nesting and fires in release builds too,
-##   because a second `pin` would silently corrupt the pinned-flag on the
-##   thread's slot — this is a safety guard, not just a debug aid.
-##   Different handles (multi-manager) are independent.
+## * `PinnedScope` (in `debra/typestates/pinned_scope`) does not allow
+##   re-pinning the same handle inside its scope. A `doAssert` inside
+##   `pinScope(unpinned(handle))` catches direct nesting and fires in
+##   release builds too, because a second `pin` would silently corrupt
+##   the pinned-flag on the thread's slot — this is a safety guard, not
+##   just a debug aid. Different handles (multi-manager) are independent.
 ## * Do not invoke explicit typestate transitions
-##   (`unpinned`/`pin`/`unpin`/`acknowledge`) inside a `withPin` body. The
-##   `try`/`finally` already manages the lifecycle; manual transitions on the
-##   same handle desync the slot's `pinned` flag.
-## * `it` injected by `withPin` is a `var RetireReady[MT]`; it is only valid
-##   inside the body. Items retired via `it.retire(...)` and `it.retireBatch(...)`
-##   are added to the thread's limbo bag at the pinned epoch and are not
-##   reclaimed until a later reclamation pass observes a safe epoch.
+##   (`unpinned`/`pin`/`unpin`/`acknowledge`) inside a live `PinnedScope`.
+##   The scope's `=destroy` already manages the lifecycle; manual
+##   transitions on the same handle desync the slot's `pinned` flag.
+## * `retireReady(scope.state)` projects the inner `Pinned[MT, CC]` to a
+##   `var RetireReady[MT, CC]` that retires through the convenience
+##   `retire(var RetireReady, ...)` / `retireBatch(var RetireReady, ...)`
+##   procs below. Items retired via `ready.retire(...)` are added to the
+##   thread's limbo bag at the pinned epoch and are not reclaimed until a
+##   later reclamation pass observes a safe epoch.
 ## * `reclaimNow` returns 0 when no epoch is safe to reclaim yet. That is
 ##   normal at startup or when no thread has advanced the epoch since the
 ##   last retire. It is not an error; reclamation is best-effort.
@@ -28,7 +31,8 @@
 ## ## Naming convention
 ##
 ## This module is the **manager-level** layer: `retire`, `retireBatch`,
-## `reclaimNow`, `retireAndReclaim`, `withPin`, and `advanceEvery` coordinate
+## `reclaimNow`, `retireAndReclaim`, and `advanceEvery` (alongside
+## `PinnedScope` in `debra/typestates/pinned_scope`) coordinate
 ## the epoch-based reclamation pipeline (deferred destruction until no thread
 ## can observe an object). They take a `(pointer, Destructor)` pair and
 ## decide *when* the destructor runs.
@@ -65,8 +69,9 @@ proc retire*[MT: static int, CC: static PinScopeCardinality = ccSingle](
   ## Retire `p` inside an existing pinned epoch held by `pin`.
   ##
   ## Wraps the sink-form `retire` from typestates/retire.nim so the caller
-  ## can chain `it.retire(...)` repeatedly inside a `withPin` body without
-  ## manually rebuilding `RetireReady` from `Retired`.
+  ## can chain `ready.retire(...)` repeatedly (e.g. on a `RetireReady`
+  ## projected from a `PinnedScope` via `retireReady(scope.state)`)
+  ## without manually rebuilding `RetireReady` from `Retired`.
   runnableExamples:
     import debra
     proc dtor(p: pointer) {.nimcall.} =
@@ -88,8 +93,9 @@ proc retireBatch*[MT: static int, CC: static PinScopeCardinality = ccSingle](
 ) =
   ## Retire each `(p, dtor)` in `items` inside an existing pinned epoch.
   ##
-  ## Must be called from within `withPin` body (or any other holder of a
-  ## `var RetireReady[MT, CC]`). No pinning, no reclamation. Avoids one
+  ## Must be called by a holder of a `var RetireReady[MT, CC]` (typically
+  ## projected from a `PinnedScope` via `retireReady(scope.state)`).
+  ## No pinning, no reclamation. Avoids one
   ## pin/unpin per object when freeing chains.
   runnableExamples:
     import debra

--- a/src/debra/convenience.nim
+++ b/src/debra/convenience.nim
@@ -370,9 +370,7 @@ proc retireAndReclaim*[MT: static int, CC: static PinScopeCardinality = ccSingle
   let retired = ready.retire(p, destructor)
 
   # Convert Retired back to Pinned for unpinning
-  let ctx = RetireContext[MT, CC](retired)
-  let pinnedAgain =
-    Pinned[MT, CC](EpochGuardContext[MT, CC](handle: ctx.handle, epoch: ctx.epoch))
+  let pinnedAgain = pinnedFromRetired(retired)
   discard pinnedAgain.unpin()
 
   # Optional eager reclamation (per-thread, scoped to this handle's slot).

--- a/src/debra/convenience.nim
+++ b/src/debra/convenience.nim
@@ -138,7 +138,7 @@ template withPin*[MT: static int, CC: static PinScopeCardinality = ccSingle](
   ## If another thread calls `neutralizeStalled` on this thread mid-body
   ## (because we stalled long enough that other threads' reclamation was
   ## blocked waiting on us), the SIGUSR1 handler force-unpins the slot
-  ## and `unpin` returns `Neutralized`. `withPin` honours the typestate
+  ## and `unpin` returns `Neutralized`. This template honours the typestate
   ## by acknowledging the neutralization in its `finally`, but it does
   ## **not** surface the fact to the caller. Code paths that need to
   ## know whether their critical section was interrupted (for example
@@ -168,7 +168,7 @@ template withPin*[MT: static int, CC: static PinScopeCardinality = ccSingle](
   block:
     let h = th
     doAssert not h.manager.threads[h.idx].pinned.load(moAcquire),
-      "withPin: thread is already pinned (handle slot " & $h.idx &
+      "deprecated pin helper: thread is already pinned (handle slot " & $h.idx &
         "). Nested pinning is forbidden."
     let pinnedGuard = unpinned(h).pin()
     var it {.inject.} = retireReady(pinnedGuard)
@@ -192,10 +192,10 @@ template withPin*[MT: static int, CC: static PinScopeCardinality = ccSingle](
     deprecated:
       "use PinnedScope: var scope = pinScope(unpinned(handle)); see CHANGELOG.md#v0.8.0"
 .} =
-  ## `withPin` variant that injects a caller-supplied identifier `name`
-  ## (instead of the default `it`). Use to disambiguate nested handles
+  ## Deprecated pin helper variant that injects a caller-supplied identifier
+  ## `name` (instead of the default `it`). Use to disambiguate nested handles
   ## across multiple managers. The neutralization pitfall described on
-  ## the unnamed `withPin` template applies here too — see that
+  ## the unnamed deprecated template applies here too — see that
   ## docstring before relying on this form for code paths that may be
   ## interrupted by `neutralizeStalled`.
   runnableExamples:
@@ -214,7 +214,7 @@ template withPin*[MT: static int, CC: static PinScopeCardinality = ccSingle](
   block:
     let h = th
     doAssert not h.manager.threads[h.idx].pinned.load(moAcquire),
-      "withPin: thread is already pinned (handle slot " & $h.idx &
+      "deprecated pin helper: thread is already pinned (handle slot " & $h.idx &
         "). Nested pinning is forbidden."
     let pinnedGuard = unpinned(h).pin()
     var name {.inject.} = retireReady(pinnedGuard)
@@ -222,7 +222,7 @@ template withPin*[MT: static int, CC: static PinScopeCardinality = ccSingle](
       body
     finally:
       # Honour the `Pinned -> Unpinned | Neutralized` typestate. Same
-      # rationale as the unnamed `withPin` form above.
+      # rationale as the unnamed deprecated form above.
       var res = pinnedGuard.unpin()
       match res:
         Unpinned(_):

--- a/src/debra/convenience.nim
+++ b/src/debra/convenience.nim
@@ -113,8 +113,7 @@ proc retireBatch*[MT: static int, CC: static PinScopeCardinality = ccSingle](
       var ready = retireReady(scope.state)
       ready.retireBatch([(a, dtor), (b, dtor)])
   for item in items:
-    if item[0] != nil:
-      pin.retire(item[0], item[1])
+    pin.retire(item[0], item[1])
 
 template withPin*[MT: static int, CC: static PinScopeCardinality = ccSingle](
     th: ThreadHandle[MT, CC], body: untyped

--- a/src/debra/convenience.nim
+++ b/src/debra/convenience.nim
@@ -52,6 +52,7 @@
 ## * `debra/typestates/retire`_ - typestate `retire` (sink form).
 ## * `debra/typestates/reclaim`_ - typestate `reclaimStart` / `tryReclaim`.
 
+import typestates # for the `{.notATransition.}` pragma
 import ./atomics
 import ./types
 import ./limbo
@@ -65,7 +66,7 @@ import ./typestates/reclaim
 
 proc retire*[MT: static int, CC: static PinScopeCardinality = ccSingle](
     pin: var RetireReady[MT, CC], p: pointer, destructor: Destructor
-) =
+) {.notATransition.} =
   ## Retire `p` inside an existing pinned epoch held by `pin`.
   ##
   ## Wraps the sink-form `retire` from typestates/retire.nim so the caller
@@ -91,7 +92,7 @@ proc retire*[MT: static int, CC: static PinScopeCardinality = ccSingle](
 
 proc retireBatch*[MT: static int, CC: static PinScopeCardinality = ccSingle](
     pin: var RetireReady[MT, CC], items: openArray[(pointer, Destructor)]
-) =
+) {.notATransition.} =
   ## Retire each `(p, dtor)` in `items` inside an existing pinned epoch.
   ##
   ## Must be called by a holder of a `var RetireReady[MT, CC]` (typically

--- a/src/debra/convenience.nim
+++ b/src/debra/convenience.nim
@@ -85,8 +85,9 @@ proc retire*[MT: static int, CC: static PinScopeCardinality = ccSingle](
       var ready = retireReady(scope.state)
       let p = alloc0(8)
       discard ready.retire(p, dtor)
-  let retired = retire(move(pin), p, destructor)
-  pin = retireReadyFromRetired(retired)
+  if p != nil:
+    let retired = retire(move(pin), p, destructor)
+    pin = retireReadyFromRetired(retired)
 
 proc retireBatch*[MT: static int, CC: static PinScopeCardinality = ccSingle](
     pin: var RetireReady[MT, CC], items: openArray[(pointer, Destructor)]
@@ -112,7 +113,8 @@ proc retireBatch*[MT: static int, CC: static PinScopeCardinality = ccSingle](
       var ready = retireReady(scope.state)
       ready.retireBatch([(a, dtor), (b, dtor)])
   for item in items:
-    pin.retire(item[0], item[1])
+    if item[0] != nil:
+      pin.retire(item[0], item[1])
 
 template withPin*[MT: static int, CC: static PinScopeCardinality = ccSingle](
     th: ThreadHandle[MT, CC], body: untyped

--- a/src/debra/refptr.nim
+++ b/src/debra/refptr.nim
@@ -152,7 +152,9 @@ proc releaseDestructor*[T](): Destructor {.inline.} =
     # Object-type spelling — canonical, matches what `retain` returns.
     # `releaseDestructor[T]()` returns the same proc address each call;
     # passing it inline costs no allocation.
-    withPin(handle):
+    block:
+      var scope = pinScope(unpinned(handle))
+      var ready = retireReady(scope.state)
       let raw = retain(Node(value: 1))
-      it.retire(raw, releaseDestructor[NodeObj]())
+      ready.retire(raw, releaseDestructor[NodeObj]())
   releaseDestructorImpl[T]

--- a/src/debra/types.nim
+++ b/src/debra/types.nim
@@ -7,6 +7,9 @@ import ./atomics
 import ./constants
 import ./limbo
 import ./thread_id
+import ./typestates/cardinality
+
+export cardinality
 
 type
   ThreadStateLive[MaxThreads: static int] = object
@@ -56,8 +59,15 @@ type
       byte,
     ]
 
-  DebraManager*[MaxThreads: static int] = object
+  DebraManager*[MaxThreads: static int, CC: static PinScopeCardinality = ccSingle] = object
     ## Coordinates epoch-based reclamation across threads.
+    ##
+    ## The `CC` parameter (introduced in 0.8.0) is the consumer-cardinality
+    ## phantom that propagates through `ThreadHandle`, `registerThread`,
+    ## and the EBR typestate graphs. It defaults to `ccSingle` so 0.7.x
+    ## call shapes compile unchanged; downstream queues set it to
+    ## `ccMulti` when multi-consumer retire-races are possible. See
+    ## `debra/typestates/cardinality.PinScopeCardinality`_.
     globalEpoch* {.align: CacheLineBytes.}: Atomic[uint64] ## Global epoch counter.
     activeThreadMask* {.align: CacheLineBytes.}: Atomic[uint64]
       ## Bitmask of registered threads.
@@ -73,10 +83,14 @@ type
       ## thread, so adjacent slots sharing a cache line would cause
       ## false-sharing on every atomic write).
 
-  ThreadHandle*[MaxThreads: static int] = object
+  ThreadHandle*[MaxThreads: static int, CC: static PinScopeCardinality = ccSingle] = object
     ## Handle for a registered thread. Required for pin/unpin.
+    ##
+    ## The `CC` parameter (introduced in 0.8.0) carries the consumer
+    ## cardinality of the pin scopes this handle will open. It defaults
+    ## to `ccSingle` so 0.7.x call shapes compile unchanged.
     idx*: int ## Index into the threads array.
-    manager*: ptr DebraManager[MaxThreads] ## Pointer to the manager.
+    manager*: ptr DebraManager[MaxThreads, CC] ## Pointer to the manager.
 
   DebraRegistrationError* = object of CatchableError
     ## Raised when thread registration fails (e.g., max threads reached).
@@ -108,6 +122,12 @@ static:
 proc initDebraManager*[MaxThreads: static int](): DebraManager[MaxThreads] =
   ## Initialize a new DEBRA+ manager.
   ##
+  ## Returns `DebraManager[MaxThreads, ccSingle]` via the CC default; the
+  ## CC axis is not inferable from a zero-argument call. Callers that
+  ## want `ccMulti` must construct the manager explicitly (e.g. via
+  ## `initDebraManager[N, ccMulti]()` once Step 8 widens the surface, or
+  ## via direct zero-initialization of the object type).
+  ##
   ## The global epoch starts at 1 (not 0) so that epoch 0 can represent
   ## "never observed" in thread state.
   result.globalEpoch.store(1'u64, moRelaxed)
@@ -122,7 +142,9 @@ proc initDebraManager*[MaxThreads: static int](): DebraManager[MaxThreads] =
     result.threads[i].limboBagTail = nil
     result.threads[i].advanceCounter = 0'u64
 
-proc `=destroy`*[MaxThreads: static int](manager: var DebraManager[MaxThreads]) =
+proc `=destroy`*[MaxThreads: static int, CC: static PinScopeCardinality](
+    manager: var DebraManager[MaxThreads, CC]
+) =
   ## Drain all per-thread limbo bags when the manager goes out of scope.
   ##
   ## Worker threads must have joined before the manager is destroyed (the

--- a/src/debra/types.nim
+++ b/src/debra/types.nim
@@ -119,14 +119,18 @@ static:
         sizeof(ThreadState[DefaultMaxThreads].cacheLinePad)
       ) & " bytes); update ThreadStateLive to mirror ThreadState"
 
-proc initDebraManager*[MaxThreads: static int](): DebraManager[MaxThreads] =
+proc initDebraManager*[
+    MaxThreads: static int, CC: static PinScopeCardinality = ccSingle
+](): DebraManager[MaxThreads, CC] =
   ## Initialize a new DEBRA+ manager.
   ##
-  ## Returns `DebraManager[MaxThreads, ccSingle]` via the CC default; the
-  ## CC axis is not inferable from a zero-argument call. Callers that
-  ## want `ccMulti` must construct the manager explicitly (e.g. via
-  ## `initDebraManager[N, ccMulti]()` once Step 8 widens the surface, or
-  ## via direct zero-initialization of the object type).
+  ## Returns `DebraManager[MaxThreads, CC]`. The `CC` axis is not
+  ## inferable from a zero-argument call, so it defaults to `ccSingle`
+  ## to keep the 0.7.x-style `initDebraManager[N]()` call shape working
+  ## unchanged. Callers that want `ccMulti` spell it explicitly:
+  ## `initDebraManager[N, ccMulti]()`. The 0.8.0 "Step 8" surface
+  ## widening is complete; direct zero-initialization of the object
+  ## type is no longer the workaround for ccMulti construction.
   ##
   ## The global epoch starts at 1 (not 0) so that epoch 0 can represent
   ## "never observed" in thread state.

--- a/src/debra/typestates/advance.nim
+++ b/src/debra/typestates/advance.nim
@@ -1,6 +1,14 @@
 ## EpochAdvance typestate for advancing the global epoch.
 ##
 ## Ensures atomic increment of the global epoch counter.
+##
+## The typestate carries a `CC: static PinScopeCardinality = ccSingle`
+## param so that ccMulti managers built by `initDebraManager[N, ccMulti]()`
+## can flow through this surface. The advance ALGORITHM is intentionally
+## CC-agnostic (pure atomic epoch arithmetic, no cardinality-dependent
+## branching), but the type system has to thread `CC` to accept a
+## `ptr DebraManager[MT, CC]` field for both cardinalities. The default
+## `ccSingle` preserves the 0.7.x-style call shape unchanged.
 
 import ../atomics
 import typestates
@@ -8,68 +16,74 @@ import typestates
 import ../types
 
 type
-  AdvanceContext*[MaxThreads: static int] = object of RootObj
-    manager*: ptr DebraManager[MaxThreads]
+  AdvanceContext*[MaxThreads: static int, CC: static PinScopeCardinality = ccSingle] = object of RootObj
+    manager*: ptr DebraManager[MaxThreads, CC]
     oldEpoch*: uint64
     newEpoch*: uint64
 
-  Current*[MaxThreads: static int] = distinct AdvanceContext[MaxThreads]
-  Advancing*[MaxThreads: static int] = distinct AdvanceContext[MaxThreads]
-  Advanced*[MaxThreads: static int] = distinct AdvanceContext[MaxThreads]
+  Current*[MaxThreads: static int, CC: static PinScopeCardinality = ccSingle] =
+    distinct AdvanceContext[MaxThreads, CC]
+  Advancing*[MaxThreads: static int, CC: static PinScopeCardinality = ccSingle] =
+    distinct AdvanceContext[MaxThreads, CC]
+  Advanced*[MaxThreads: static int, CC: static PinScopeCardinality = ccSingle] =
+    distinct AdvanceContext[MaxThreads, CC]
 
-typestate AdvanceContext[MaxThreads: static int]:
+typestate AdvanceContext[MaxThreads: static int, CC: static PinScopeCardinality]:
   inheritsFromRootObj = true
   opaqueStates = true
-  states Current[MaxThreads], Advancing[MaxThreads], Advanced[MaxThreads]
+  defaults:
+    CC:
+      ccSingle
+  states Current[MaxThreads, CC], Advancing[MaxThreads, CC], Advanced[MaxThreads, CC]
   initial:
-    Current[MaxThreads]
+    Current[MaxThreads, CC]
   terminal:
-    Advanced[MaxThreads]
+    Advanced[MaxThreads, CC]
   transitions:
-    Current[MaxThreads] -> Advancing[MaxThreads]
-    Advancing[MaxThreads] -> Advanced[MaxThreads]
+    Current[MaxThreads, CC] -> Advancing[MaxThreads, CC]
+    Advancing[MaxThreads, CC] -> Advanced[MaxThreads, CC]
 
-proc advanceCurrent*[MaxThreads: static int](
-    mgr: ptr DebraManager[MaxThreads]
-): Current[MaxThreads] =
+proc advanceCurrent*[MaxThreads: static int, CC: static PinScopeCardinality = ccSingle](
+    mgr: ptr DebraManager[MaxThreads, CC]
+): Current[MaxThreads, CC] =
   ## Create epoch advance context.
-  Current[MaxThreads](
-    AdvanceContext[MaxThreads](manager: mgr, oldEpoch: 0, newEpoch: 0)
+  Current[MaxThreads, CC](
+    AdvanceContext[MaxThreads, CC](manager: mgr, oldEpoch: 0, newEpoch: 0)
   )
 
-proc advance*[MaxThreads: static int](
-    c: sink Current[MaxThreads]
-): Advancing[MaxThreads] {.transition.} =
+proc advance*[MaxThreads: static int, CC: static PinScopeCardinality](
+    c: sink Current[MaxThreads, CC]
+): Advancing[MaxThreads, CC] {.transition.} =
   ## Begin advancing the global epoch.
-  let ctx = AdvanceContext[MaxThreads](c)
-  Advancing[MaxThreads](
-    AdvanceContext[MaxThreads](manager: ctx.manager, oldEpoch: 0, newEpoch: 0)
+  let ctx = AdvanceContext[MaxThreads, CC](c)
+  Advancing[MaxThreads, CC](
+    AdvanceContext[MaxThreads, CC](manager: ctx.manager, oldEpoch: 0, newEpoch: 0)
   )
 
-proc complete*[MaxThreads: static int](
-    a: sink Advancing[MaxThreads]
-): Advanced[MaxThreads] {.transition.} =
+proc complete*[MaxThreads: static int, CC: static PinScopeCardinality](
+    a: sink Advancing[MaxThreads, CC]
+): Advanced[MaxThreads, CC] {.transition.} =
   ## Complete epoch advance by atomically incrementing globalEpoch.
-  let ctx = AdvanceContext[MaxThreads](a)
+  let ctx = AdvanceContext[MaxThreads, CC](a)
 
   # Atomically increment the global epoch using fetchAdd
   let oldEpoch = ctx.manager.globalEpoch.fetchAdd(1'u64, moRelease)
   let newEpoch = oldEpoch + 1'u64
 
-  Advanced[MaxThreads](
-    AdvanceContext[MaxThreads](
+  Advanced[MaxThreads, CC](
+    AdvanceContext[MaxThreads, CC](
       manager: ctx.manager, oldEpoch: oldEpoch, newEpoch: newEpoch
     )
   )
 
-func newEpoch*[MaxThreads: static int](
-    a: Advanced[MaxThreads]
+func newEpoch*[MaxThreads: static int, CC: static PinScopeCardinality](
+    a: Advanced[MaxThreads, CC]
 ): uint64 {.notATransition.} =
   ## Get the new epoch value after advancement.
-  AdvanceContext[MaxThreads](a).newEpoch
+  AdvanceContext[MaxThreads, CC](a).newEpoch
 
-func oldEpoch*[MaxThreads: static int](
-    a: Advanced[MaxThreads]
+func oldEpoch*[MaxThreads: static int, CC: static PinScopeCardinality](
+    a: Advanced[MaxThreads, CC]
 ): uint64 {.notATransition.} =
   ## Get the old epoch value before advancement.
-  AdvanceContext[MaxThreads](a).oldEpoch
+  AdvanceContext[MaxThreads, CC](a).oldEpoch

--- a/src/debra/typestates/cardinality.nim
+++ b/src/debra/typestates/cardinality.nim
@@ -1,0 +1,23 @@
+## Cardinality axis for the typestate surface (introduced in 0.8.0).
+##
+## `PinScopeCardinality` is the second generic-parameter axis (the **CC**
+## axis) that nim-debra threads through `DebraManager`, `ThreadHandle`,
+## and the EBR typestate graphs. It exposes consumer-cardinality at the
+## type level so downstream lock-free data structures can statically gate
+## single-writer atomic primitives (`retireOnPublish`) from
+## CAS-based primitives (`retireOnCAS`).
+##
+## Values:
+##
+## * `ccSingle` - single consumer / no retire-race. **Default** for every
+##   call shape in 0.7.x-compat code. Used for producer-side pins and
+##   true single-consumer queue contexts.
+## * `ccMulti` - multi-consumer / retire-race possible. Required for
+##   consumer pins on multi-consumer queues.
+##
+## The CC parameter defaults to `ccSingle` everywhere Nim's `static`
+## defaulting reaches, so existing 0.7.x callers compile unchanged.
+
+type PinScopeCardinality* = enum
+  ccSingle
+  ccMulti

--- a/src/debra/typestates/guard.nim
+++ b/src/debra/typestates/guard.nim
@@ -2,6 +2,32 @@
 ##
 ## Ensures threads properly enter/exit critical sections.
 ##
+## The typestate carries two static generic-param axes:
+##
+## - `MaxThreads: static int` — capacity of the manager's thread array.
+## - `CC: static PinScopeCardinality = ccSingle` — consumer-cardinality
+##   phantom mirroring `DebraManager` / `ThreadHandle` /
+##   `RegistrationContext`. Default `ccSingle` matches the 0.7.x call
+##   shape, so existing call sites that spell only `MaxThreads` continue
+##   to bind cleanly.
+##
+## Codegen-emitted helpers (variant type `UnpinResult`, `=copy` hooks,
+## `state()` procs, `$` overloads, `match` macros) inherit `CC = ccSingle`
+## via the typestate macro's `defaults:` body section (typestates 0.9.2+).
+##
+## ## States
+##
+## * `Unpinned` — outside a critical section. Constructed via `unpinned`.
+## * `Pinned` — inside a critical section, epoch captured.
+## * `Neutralized` — was Pinned, then signaled; must `acknowledge`
+##   before re-pinning.
+## * `Closed` — terminal state reached only by the destructor path of
+##   `PinnedScope` (or the deprecated `withPin` finalizer). User code
+##   SHOULD NOT call `close` directly; rely on `PinnedScope` to drive
+##   the lifecycle. `close` performs no atomic operations — the slot's
+##   `pinned` / `neutralized` flags were already cleared by the
+##   preceding `unpin` (or `unpin + acknowledge`) call.
+##
 ## ## Pitfalls
 ##
 ## * The `Unpinned` -> `Pinned` -> `Unpinned`/`Neutralized` typestate sequence
@@ -13,7 +39,7 @@
 ##   the critical section. Call `acknowledge` before re-pinning. Skipping
 ##   `acknowledge` will leave the slot's `neutralized` flag set, and the
 ##   next `pin`/`unpin` cycle will misreport state.
-## * `Pinned[MT]` carries the captured `epoch` field; do not mutate the
+## * `Pinned[MT, CC]` carries the captured `epoch` field; do not mutate the
 ##   manager's global epoch under the assumption a particular `Pinned` value
 ##   tracks it. Advance the manager epoch on the worker side, then re-pin to
 ##   refresh.
@@ -28,34 +54,56 @@ import typestates
 
 import ../types
 
+# `PinScopeCardinality` reaches this module via `../types` (re-exported
+# from `./cardinality`).
+
 type
-  EpochGuardContext*[MaxThreads: static int] = object of RootObj
-    handle*: ThreadHandle[MaxThreads]
+  EpochGuardContext*[MaxThreads: static int, CC: static PinScopeCardinality = ccSingle] = object of RootObj
+    handle*: ThreadHandle[MaxThreads, CC]
     epoch*: uint64
 
-  Unpinned*[MaxThreads: static int] = distinct EpochGuardContext[MaxThreads]
-  Pinned*[MaxThreads: static int] = distinct EpochGuardContext[MaxThreads]
-  Neutralized*[MaxThreads: static int] = distinct EpochGuardContext[MaxThreads]
+  Unpinned*[MaxThreads: static int, CC: static PinScopeCardinality = ccSingle] =
+    distinct EpochGuardContext[MaxThreads, CC]
 
-typestate EpochGuardContext[MaxThreads: static int]:
+  Pinned*[MaxThreads: static int, CC: static PinScopeCardinality = ccSingle] =
+    distinct EpochGuardContext[MaxThreads, CC]
+
+  Neutralized*[MaxThreads: static int, CC: static PinScopeCardinality = ccSingle] =
+    distinct EpochGuardContext[MaxThreads, CC]
+
+  Closed*[MaxThreads: static int, CC: static PinScopeCardinality = ccSingle] =
+    distinct EpochGuardContext[MaxThreads, CC]
+
+typestate EpochGuardContext[MaxThreads: static int, CC: static PinScopeCardinality]:
   inheritsFromRootObj = true
   consumeOnTransition = false # Allow values to be passed across typestate boundaries
-  states Unpinned[MaxThreads], Pinned[MaxThreads], Neutralized[MaxThreads]
+  defaults:
+    CC:
+      ccSingle
+  states:
+    Unpinned[MaxThreads, CC]
+    Pinned[MaxThreads, CC]
+    Neutralized[MaxThreads, CC]
+    Closed[MaxThreads, CC]
+  terminal:
+    Closed[MaxThreads, CC]
   transitions:
-    Unpinned[MaxThreads] -> Pinned[MaxThreads]
-    Pinned[MaxThreads] ->
-      Unpinned[MaxThreads] | Neutralized[MaxThreads] as UnpinResult[MaxThreads]
-    Neutralized[MaxThreads] -> Unpinned[MaxThreads]
+    Unpinned[MaxThreads, CC] -> Pinned[MaxThreads, CC]
+    Pinned[MaxThreads, CC] ->
+      Unpinned[MaxThreads, CC] | Neutralized[MaxThreads, CC] as
+      UnpinResult[MaxThreads, CC]
+    Neutralized[MaxThreads, CC] -> Unpinned[MaxThreads, CC]
+    Unpinned[MaxThreads, CC] -> Closed[MaxThreads, CC]
 
-proc unpinned*[MaxThreads: static int](
-    handle: ThreadHandle[MaxThreads]
-): Unpinned[MaxThreads] =
+proc unpinned*[MaxThreads: static int, CC: static PinScopeCardinality](
+    handle: ThreadHandle[MaxThreads, CC]
+): Unpinned[MaxThreads, CC] =
   ## Create unpinned epoch guard context.
-  Unpinned[MaxThreads](EpochGuardContext[MaxThreads](handle: handle, epoch: 0))
+  Unpinned[MaxThreads, CC](EpochGuardContext[MaxThreads, CC](handle: handle, epoch: 0))
 
-proc pin*[MaxThreads: static int](
-    u: sink Unpinned[MaxThreads]
-): Pinned[MaxThreads] {.transition.} =
+proc pin*[MaxThreads: static int, CC: static PinScopeCardinality](
+    u: sink Unpinned[MaxThreads, CC]
+): Pinned[MaxThreads, CC] {.transition.} =
   ## Enter critical section. Blocks reclamation of current epoch.
   runnableExamples:
     import debra
@@ -64,7 +112,7 @@ proc pin*[MaxThreads: static int](
     let handle = registerThread(manager)
     let pinned = unpinned(handle).pin()
     discard pinned.unpin()
-  var ctx = EpochGuardContext[MaxThreads](u)
+  var ctx = EpochGuardContext[MaxThreads, CC](u)
   let mgr = ctx.handle.manager
   let idx = ctx.handle.idx
 
@@ -88,11 +136,11 @@ proc pin*[MaxThreads: static int](
   # and Crossbeam uses the same encoding for the same reason.
   discard mgr.threads[idx].pinned.exchange(true, moSequentiallyConsistent)
 
-  Pinned[MaxThreads](ctx)
+  Pinned[MaxThreads, CC](ctx)
 
-proc unpin*[MaxThreads: static int](
-    p: sink Pinned[MaxThreads]
-): UnpinResult[MaxThreads] {.transition.} =
+proc unpin*[MaxThreads: static int, CC: static PinScopeCardinality](
+    p: sink Pinned[MaxThreads, CC]
+): UnpinResult[MaxThreads, CC] {.transition.} =
   ## Leave critical section. Returns Neutralized if signaled.
   runnableExamples:
     import debra
@@ -106,7 +154,7 @@ proc unpin*[MaxThreads: static int](
         discard
       Neutralized(nval):
         discard nval.acknowledge()
-  let ctx = EpochGuardContext[MaxThreads](p)
+  let ctx = EpochGuardContext[MaxThreads, CC](p)
   let mgr = ctx.handle.manager
   let idx = ctx.handle.idx
 
@@ -118,26 +166,43 @@ proc unpin*[MaxThreads: static int](
   mgr.threads[idx].pinned.store(false, moSequentiallyConsistent)
 
   if mgr.threads[idx].neutralized.load(moAcquire):
-    UnpinResult[MaxThreads] -> Neutralized[MaxThreads](ctx)
+    UnpinResult[MaxThreads, CC] -> Neutralized[MaxThreads, CC](ctx)
   else:
-    UnpinResult[MaxThreads] -> Unpinned[MaxThreads](ctx)
+    UnpinResult[MaxThreads, CC] -> Unpinned[MaxThreads, CC](ctx)
 
-proc acknowledge*[MaxThreads: static int](
-    n: sink Neutralized[MaxThreads]
-): Unpinned[MaxThreads] {.transition.} =
+proc acknowledge*[MaxThreads: static int, CC: static PinScopeCardinality](
+    n: sink Neutralized[MaxThreads, CC]
+): Unpinned[MaxThreads, CC] {.transition.} =
   ## Acknowledge neutralization. Required before re-pinning.
   ##
   ## See also: `unpin`_ (returns `Neutralized` when signaled), `pin`_.
-  let ctx = EpochGuardContext[MaxThreads](n)
+  let ctx = EpochGuardContext[MaxThreads, CC](n)
   ctx.handle.manager.threads[ctx.handle.idx].neutralized.store(false, moRelease)
-  Unpinned[MaxThreads](EpochGuardContext[MaxThreads](handle: ctx.handle, epoch: 0))
+  Unpinned[MaxThreads, CC](
+    EpochGuardContext[MaxThreads, CC](handle: ctx.handle, epoch: 0)
+  )
 
-func epoch*[MaxThreads: static int](p: Pinned[MaxThreads]): uint64 {.notATransition.} =
+proc close*[MaxThreads: static int, CC: static PinScopeCardinality](
+    u: sink Unpinned[MaxThreads, CC]
+): Closed[MaxThreads, CC] {.transition.} =
+  ## One-way exit transition for `PinnedScope`'s destructor path.
+  ##
+  ## `close` is reserved for the `PinnedScope.=destroy` path; user code
+  ## should rely on `PinnedScope` (or the deprecated `withPin`) to drive
+  ## the lifecycle and should not call `close` directly. `close` performs
+  ## no atomic operations; the slot's `pinned` and `neutralized` flags
+  ## were already cleared by the preceding `unpin` (or `unpin +
+  ## acknowledge`) call.
+  Closed[MaxThreads, CC](EpochGuardContext[MaxThreads, CC](u))
+
+func epoch*[MaxThreads: static int, CC: static PinScopeCardinality](
+    p: Pinned[MaxThreads, CC]
+): uint64 {.notATransition.} =
   ## Get the epoch this thread is pinned at.
-  EpochGuardContext[MaxThreads](p).epoch
+  EpochGuardContext[MaxThreads, CC](p).epoch
 
-func handle*[MaxThreads: static int](
-    p: Pinned[MaxThreads]
-): ThreadHandle[MaxThreads] {.notATransition.} =
+func handle*[MaxThreads: static int, CC: static PinScopeCardinality](
+    p: Pinned[MaxThreads, CC]
+): ThreadHandle[MaxThreads, CC] {.notATransition.} =
   ## Get the thread handle.
-  EpochGuardContext[MaxThreads](p).handle
+  EpochGuardContext[MaxThreads, CC](p).handle

--- a/src/debra/typestates/guard.nim
+++ b/src/debra/typestates/guard.nim
@@ -22,19 +22,18 @@
 ## * `Neutralized` — was Pinned, then signaled; must `acknowledge`
 ##   before re-pinning.
 ## * `Closed` — terminal state reached only by the destructor path of
-##   `PinnedScope` (or the deprecated `withPin` finalizer). User code
-##   SHOULD NOT call `close` directly; rely on `PinnedScope` to drive
-##   the lifecycle. `close` performs no atomic operations — the slot's
-##   `pinned` / `neutralized` flags were already cleared by the
-##   preceding `unpin` (or `unpin + acknowledge`) call.
+##   `PinnedScope`. User code SHOULD NOT call `close` directly; rely on
+##   `PinnedScope` to drive the lifecycle. `close` performs no atomic
+##   operations — the slot's `pinned` / `neutralized` flags were already
+##   cleared by the preceding `unpin` (or `unpin + acknowledge`) call.
 ##
 ## ## Pitfalls
 ##
 ## * The `Unpinned` -> `Pinned` -> `Unpinned`/`Neutralized` typestate sequence
 ##   must be respected. Calling `pin` on a handle that is already pinned at
 ##   the slot level (the manager's `threads[idx].pinned` flag is true) leaves
-##   the slot inconsistent. Use `withPin` (in `debra/convenience`) for the
-##   common path; reach for the typestate API only when you need finer control.
+##   the slot inconsistent. Use `PinnedScope` (in `debra/typestates/pinned_scope`)
+##   for the common path; reach for the typestate API only when you need finer control.
 ## * If `unpin` returns `Neutralized`, the thread was signaled while inside
 ##   the critical section. Call `acknowledge` before re-pinning. Skipping
 ##   `acknowledge` will leave the slot's `neutralized` flag set, and the
@@ -46,7 +45,7 @@
 ##
 ## ## See also
 ##
-## * `debra/convenience.withPin`_ - the recommended high-level wrapper.
+## * `debra/typestates/pinned_scope.PinnedScope`_ - the recommended high-level RAII guard.
 ## * `debra/typestates/retire`_ - `RetireReady` constructed from `Pinned`.
 
 import ../atomics
@@ -188,8 +187,8 @@ proc close*[MaxThreads: static int, CC: static PinScopeCardinality](
   ## One-way exit transition for `PinnedScope`'s destructor path.
   ##
   ## `close` is reserved for the `PinnedScope.=destroy` path; user code
-  ## should rely on `PinnedScope` (or the deprecated `withPin`) to drive
-  ## the lifecycle and should not call `close` directly. `close` performs
+  ## should rely on `PinnedScope` to drive the lifecycle and should not
+  ## call `close` directly. `close` performs
   ## no atomic operations; the slot's `pinned` and `neutralized` flags
   ## were already cleared by the preceding `unpin` (or `unpin +
   ## acknowledge`) call.

--- a/src/debra/typestates/manager.nim
+++ b/src/debra/typestates/manager.nim
@@ -10,37 +10,44 @@ import ../limbo
 import ../thread_id
 
 type
-  ManagerContext*[MaxThreads: static int] = object of RootObj
-    manager*: ptr DebraManager[MaxThreads]
+  ManagerContext*[MaxThreads: static int, CC: static PinScopeCardinality = ccSingle] = object of RootObj
+    manager*: ptr DebraManager[MaxThreads, CC]
 
-  ManagerUninitialized*[MaxThreads: static int] = distinct ManagerContext[MaxThreads]
-  ManagerReady*[MaxThreads: static int] = distinct ManagerContext[MaxThreads]
-  ManagerShutdown*[MaxThreads: static int] = distinct ManagerContext[MaxThreads]
+  ManagerUninitialized*[
+    MaxThreads: static int, CC: static PinScopeCardinality = ccSingle
+  ] = distinct ManagerContext[MaxThreads, CC]
+  ManagerReady*[MaxThreads: static int, CC: static PinScopeCardinality = ccSingle] =
+    distinct ManagerContext[MaxThreads, CC]
+  ManagerShutdown*[MaxThreads: static int, CC: static PinScopeCardinality = ccSingle] =
+    distinct ManagerContext[MaxThreads, CC]
 
-typestate ManagerContext[MaxThreads: static int]:
+typestate ManagerContext[MaxThreads: static int, CC: static PinScopeCardinality]:
   inheritsFromRootObj = true
   opaqueStates = true
-  states ManagerUninitialized[MaxThreads],
-    ManagerReady[MaxThreads], ManagerShutdown[MaxThreads]
+  defaults:
+    CC:
+      ccSingle
+  states ManagerUninitialized[MaxThreads, CC],
+    ManagerReady[MaxThreads, CC], ManagerShutdown[MaxThreads, CC]
   initial:
-    ManagerUninitialized[MaxThreads]
+    ManagerUninitialized[MaxThreads, CC]
   terminal:
-    ManagerShutdown[MaxThreads]
+    ManagerShutdown[MaxThreads, CC]
   transitions:
-    ManagerUninitialized[MaxThreads] -> ManagerReady[MaxThreads]
-    ManagerReady[MaxThreads] -> ManagerShutdown[MaxThreads]
+    ManagerUninitialized[MaxThreads, CC] -> ManagerReady[MaxThreads, CC]
+    ManagerReady[MaxThreads, CC] -> ManagerShutdown[MaxThreads, CC]
 
-proc uninitializedManager*[MaxThreads: static int](
-    mgr: ptr DebraManager[MaxThreads]
-): ManagerUninitialized[MaxThreads] =
+proc uninitializedManager*[
+    MaxThreads: static int, CC: static PinScopeCardinality = ccSingle
+](mgr: ptr DebraManager[MaxThreads, CC]): ManagerUninitialized[MaxThreads, CC] =
   ## Wrap a manager pointer as uninitialized.
-  ManagerUninitialized[MaxThreads](ManagerContext[MaxThreads](manager: mgr))
+  ManagerUninitialized[MaxThreads, CC](ManagerContext[MaxThreads, CC](manager: mgr))
 
-proc initialize*[MaxThreads: static int](
-    m: sink ManagerUninitialized[MaxThreads]
-): ManagerReady[MaxThreads] {.transition.} =
+proc initialize*[MaxThreads: static int, CC: static PinScopeCardinality](
+    m: sink ManagerUninitialized[MaxThreads, CC]
+): ManagerReady[MaxThreads, CC] {.transition.} =
   ## Initialize the manager. Sets epoch to 1, clears all state.
-  let ctx = ManagerContext[MaxThreads](m)
+  let ctx = ManagerContext[MaxThreads, CC](m)
   let mgr = ctx.manager
   mgr.globalEpoch.store(1'u64, moRelaxed)
   mgr.activeThreadMask.store(0'u64, moRelaxed)
@@ -52,13 +59,13 @@ proc initialize*[MaxThreads: static int](
     mgr.threads[i].threadId.store(InvalidThreadId, moRelaxed)
     mgr.threads[i].currentBag = nil
     mgr.threads[i].limboBagTail = nil
-  ManagerReady[MaxThreads](ManagerContext[MaxThreads](manager: mgr))
+  ManagerReady[MaxThreads, CC](ManagerContext[MaxThreads, CC](manager: mgr))
 
-proc shutdown*[MaxThreads: static int](
-    m: sink ManagerReady[MaxThreads]
-): ManagerShutdown[MaxThreads] {.transition.} =
+proc shutdown*[MaxThreads: static int, CC: static PinScopeCardinality](
+    m: sink ManagerReady[MaxThreads, CC]
+): ManagerShutdown[MaxThreads, CC] {.transition.} =
   ## Shutdown manager. Reclaims all remaining limbo bags.
-  let ctx = ManagerContext[MaxThreads](m)
+  let ctx = ManagerContext[MaxThreads, CC](m)
   let mgr = ctx.manager
   for i in 0 ..< MaxThreads:
     # Reclaim all limbo bags for this thread
@@ -72,10 +79,10 @@ proc shutdown*[MaxThreads: static int](
       bag = next
     mgr.threads[i].currentBag = nil
     mgr.threads[i].limboBagTail = nil
-  ManagerShutdown[MaxThreads](ManagerContext[MaxThreads](manager: mgr))
+  ManagerShutdown[MaxThreads, CC](ManagerContext[MaxThreads, CC](manager: mgr))
 
-func getManager*[MaxThreads: static int](
-    m: ManagerReady[MaxThreads]
-): ptr DebraManager[MaxThreads] =
+func getManager*[MaxThreads: static int, CC: static PinScopeCardinality](
+    m: ManagerReady[MaxThreads, CC]
+): ptr DebraManager[MaxThreads, CC] =
   ## Get the underlying manager pointer.
-  ManagerContext[MaxThreads](m).manager
+  ManagerContext[MaxThreads, CC](m).manager

--- a/src/debra/typestates/manager.nim
+++ b/src/debra/typestates/manager.nim
@@ -83,6 +83,6 @@ proc shutdown*[MaxThreads: static int, CC: static PinScopeCardinality](
 
 func getManager*[MaxThreads: static int, CC: static PinScopeCardinality](
     m: ManagerReady[MaxThreads, CC]
-): ptr DebraManager[MaxThreads, CC] =
+): ptr DebraManager[MaxThreads, CC] {.notATransition.} =
   ## Get the underlying manager pointer.
   ManagerContext[MaxThreads, CC](m).manager

--- a/src/debra/typestates/neutralize.nim
+++ b/src/debra/typestates/neutralize.nim
@@ -13,44 +13,51 @@ import ../constants
 import ../thread_id
 
 type
-  NeutralizeContext*[MaxThreads: static int] = object of RootObj
-    manager*: ptr DebraManager[MaxThreads]
+  NeutralizeContext*[MaxThreads: static int, CC: static PinScopeCardinality = ccSingle] = object of RootObj
+    manager*: ptr DebraManager[MaxThreads, CC]
     globalEpoch*: uint64
     threshold*: uint64
     signalsSent*: int
 
-  ScanStart*[MaxThreads: static int] = distinct NeutralizeContext[MaxThreads]
-  Scanning*[MaxThreads: static int] = distinct NeutralizeContext[MaxThreads]
-  ScanComplete*[MaxThreads: static int] = distinct NeutralizeContext[MaxThreads]
+  ScanStart*[MaxThreads: static int, CC: static PinScopeCardinality = ccSingle] =
+    distinct NeutralizeContext[MaxThreads, CC]
+  Scanning*[MaxThreads: static int, CC: static PinScopeCardinality = ccSingle] =
+    distinct NeutralizeContext[MaxThreads, CC]
+  ScanComplete*[MaxThreads: static int, CC: static PinScopeCardinality = ccSingle] =
+    distinct NeutralizeContext[MaxThreads, CC]
 
-typestate NeutralizeContext[MaxThreads: static int]:
+typestate NeutralizeContext[MaxThreads: static int, CC: static PinScopeCardinality]:
   inheritsFromRootObj = true
   opaqueStates = true
-  states ScanStart[MaxThreads], Scanning[MaxThreads], ScanComplete[MaxThreads]
+  defaults:
+    CC:
+      ccSingle
+  states ScanStart[MaxThreads, CC],
+    Scanning[MaxThreads, CC], ScanComplete[MaxThreads, CC]
   initial:
-    ScanStart[MaxThreads]
+    ScanStart[MaxThreads, CC]
   terminal:
-    ScanComplete[MaxThreads]
+    ScanComplete[MaxThreads, CC]
   transitions:
-    ScanStart[MaxThreads] -> Scanning[MaxThreads]
-    Scanning[MaxThreads] -> ScanComplete[MaxThreads]
+    ScanStart[MaxThreads, CC] -> Scanning[MaxThreads, CC]
+    Scanning[MaxThreads, CC] -> ScanComplete[MaxThreads, CC]
 
-proc scanStart*[MaxThreads: static int](
-    mgr: ptr DebraManager[MaxThreads]
-): ScanStart[MaxThreads] =
+proc scanStart*[MaxThreads: static int, CC: static PinScopeCardinality = ccSingle](
+    mgr: ptr DebraManager[MaxThreads, CC]
+): ScanStart[MaxThreads, CC] =
   ## Begin neutralization scan.
-  ScanStart[MaxThreads](
-    NeutralizeContext[MaxThreads](
+  ScanStart[MaxThreads, CC](
+    NeutralizeContext[MaxThreads, CC](
       manager: mgr, globalEpoch: 0, threshold: 0, signalsSent: 0
     )
   )
 
-proc loadEpoch*[MaxThreads: static int](
-    s: ScanStart[MaxThreads], epochsBeforeNeutralize: uint64 = 2
-): Scanning[MaxThreads] {.transition.} =
+proc loadEpoch*[MaxThreads: static int, CC: static PinScopeCardinality](
+    s: ScanStart[MaxThreads, CC], epochsBeforeNeutralize: uint64 = 2
+): Scanning[MaxThreads, CC] {.transition.} =
   ## Load global epoch and compute threshold for stalled threads.
   ## Threads with epoch < (globalEpoch - epochsBeforeNeutralize) get signaled.
-  var ctx = NeutralizeContext[MaxThreads](s)
+  var ctx = NeutralizeContext[MaxThreads, CC](s)
   ctx.globalEpoch = ctx.manager.globalEpoch.load(moAcquire)
 
   ctx.threshold =
@@ -59,26 +66,26 @@ proc loadEpoch*[MaxThreads: static int](
     else:
       0'u64
 
-  result = Scanning[MaxThreads](ctx)
+  result = Scanning[MaxThreads, CC](ctx)
 
-func globalEpoch*[MaxThreads: static int](
-    s: Scanning[MaxThreads]
+func globalEpoch*[MaxThreads: static int, CC: static PinScopeCardinality](
+    s: Scanning[MaxThreads, CC]
 ): uint64 {.notATransition.} =
   ## Get the global epoch loaded during scan start.
-  NeutralizeContext[MaxThreads](s).globalEpoch
+  NeutralizeContext[MaxThreads, CC](s).globalEpoch
 
-func threshold*[MaxThreads: static int](
-    s: Scanning[MaxThreads]
+func threshold*[MaxThreads: static int, CC: static PinScopeCardinality](
+    s: Scanning[MaxThreads, CC]
 ): uint64 {.notATransition.} =
   ## Get the epoch threshold for neutralization.
-  NeutralizeContext[MaxThreads](s).threshold
+  NeutralizeContext[MaxThreads, CC](s).threshold
 
-proc scanAndSignal*[MaxThreads: static int](
-    s: Scanning[MaxThreads]
-): ScanComplete[MaxThreads] {.transition.} =
+proc scanAndSignal*[MaxThreads: static int, CC: static PinScopeCardinality](
+    s: Scanning[MaxThreads, CC]
+): ScanComplete[MaxThreads, CC] {.transition.} =
   ## Scan all registered threads and send SIGUSR1 to stalled pinned threads.
   ## Returns count of signals sent.
-  var ctx = NeutralizeContext[MaxThreads](s)
+  var ctx = NeutralizeContext[MaxThreads, CC](s)
   let activeMask = ctx.manager.activeThreadMask.load(moAcquire)
   let currentTid = currentThreadId()
 
@@ -96,16 +103,16 @@ proc scanAndSignal*[MaxThreads: static int](
             discard tid.sendSignal(QuiescentSignal)
             inc ctx.signalsSent
 
-  result = ScanComplete[MaxThreads](ctx)
+  result = ScanComplete[MaxThreads, CC](ctx)
 
-func signalsSent*[MaxThreads: static int](
-    c: ScanComplete[MaxThreads]
+func signalsSent*[MaxThreads: static int, CC: static PinScopeCardinality](
+    c: ScanComplete[MaxThreads, CC]
 ): int {.notATransition.} =
   ## Get number of signals sent during scan.
-  NeutralizeContext[MaxThreads](c).signalsSent
+  NeutralizeContext[MaxThreads, CC](c).signalsSent
 
-func extractSignalCount*[MaxThreads: static int](
-    c: ScanComplete[MaxThreads]
+func extractSignalCount*[MaxThreads: static int, CC: static PinScopeCardinality](
+    c: ScanComplete[MaxThreads, CC]
 ): int {.notATransition.} =
   ## Extract the count of signals sent. Terminal operation.
-  NeutralizeContext[MaxThreads](c).signalsSent
+  NeutralizeContext[MaxThreads, CC](c).signalsSent

--- a/src/debra/typestates/pinned_scope.nim
+++ b/src/debra/typestates/pinned_scope.nim
@@ -123,6 +123,11 @@ proc pinScope*[MT: static int, CC: static PinScopeCardinality](
   # outer constructor produces a value in PinnedScopeLifecycle's initial
   # state PinnedScopeAlive via the
   # {.PinnedScopeLifecycle: PinnedScopeAlive.} attachment pragma.
+  # `u` (a sink param) is READ, not consumed, here: converting to
+  # EpochGuardContext is a non-destructive field read, and Nim's move
+  # analysis keeps `u` live because `u.pin()` below is its sole consumer. The
+  # handle must be read BEFORE pin(), since pin() sets the slot `pinned` flag
+  # that the re-entrancy doAssert checks.
   let handleVal = EpochGuardContext[MT, CC](u).handle
   let idx = handleVal.idx
   doAssert(
@@ -134,7 +139,8 @@ proc pinScope*[MT: static int, CC: static PinScopeCardinality](
 proc retireOnCAS*[MT: static int, CC: static PinScopeCardinality, T](
     scope: var PinnedScope[MT, CC],
     atomic: var Atomic[T],
-    expected, desired: T,
+    expected: var T,
+    desired: T,
     dtor: Destructor,
 ): bool {.discardable, raises: [].} =
   ## Atomically swap a published pointer and retire the displaced value.
@@ -145,6 +151,10 @@ proc retireOnCAS*[MT: static int, CC: static PinScopeCardinality, T](
   ##
   ## Callable under any `CC` (DR-S3).
   ##
+  ## `expected` is an in/out parameter: on CAS failure it is updated to the
+  ## value actually observed (as in stdlib `compareExchange`), so a retry
+  ## loop need not re-load before the next attempt.
+  ##
   ## **`T` contract:** `T` must be a raw pointer type (`ptr X` or
   ## `pointer`). The displaced value is `cast[pointer]` and reclaimed via
   ## `dtor`. Do NOT instantiate over a `ref` type: refs are GC-managed, so
@@ -152,8 +162,11 @@ proc retireOnCAS*[MT: static int, CC: static PinScopeCardinality, T](
   ## intentionally left unconstrained so downstream wrappers can forward
   ## their own pointer-shaped element type; the constraint is a documented
   ## caller contract, not a static bound.
-  var exp = expected
-  if atomic.compareExchange(exp, desired, moAcquireRelease, moAcquire):
+  # `expected` is an in/out param (matches stdlib `compareExchange`): on CAS
+  # failure `compareExchange` writes the observed value back into it so a
+  # caller retry loop need not re-load. On success it is unchanged and still
+  # holds the displaced value we retire below.
+  if atomic.compareExchange(expected, desired, moAcquireRelease, moAcquire):
     # Rotate: Pinned -> RetireReady (BY-VALUE per DR-P3) -> Retired -> Pinned.
     # retireReady is by-value over Pinned (does not consume scope.state in
     # the typestate sense); the resulting RetireReady is the sink param for
@@ -161,7 +174,7 @@ proc retireOnCAS*[MT: static int, CC: static PinScopeCardinality, T](
     # Pinned in the same epoch so the scope remains usable for further
     # retires inside the same pinned section.
     var ready = retireReady(scope.state)
-    let retired = ready.retire(cast[pointer](exp), dtor)
+    let retired = ready.retire(cast[pointer](expected), dtor)
     scope.state = pinnedFromRetired(retired)
     return true
   return false

--- a/src/debra/typestates/pinned_scope.nim
+++ b/src/debra/typestates/pinned_scope.nim
@@ -1,0 +1,207 @@
+## PinnedScope RAII guard for pin-scoped retire.
+##
+## `PinnedScope[MT, CC]` is the recommended high-level entry point for the
+## pin/retire/unpin cycle, replacing the deprecated `withPin` template.
+## Construct via `pinScope(unpinned(handle))`; destruction (block exit, scope
+## end, explicit `=destroy`) drives the underlying `EpochGuardContext`
+## through `unpin` (and, if signaled, `acknowledge`) and finally `close`,
+## clearing the slot's `pinned` flag.
+##
+## The typestate carries two static generic-param axes:
+##
+## - `MT: static int` — capacity of the manager's thread array.
+## - `CC: static PinScopeCardinality = ccSingle` — consumer-cardinality
+##   phantom mirroring `DebraManager` / `ThreadHandle` / `EpochGuardContext`
+##   / `RetireContext`. Default `ccSingle` matches the 0.7.x call shape.
+##
+## Codegen-emitted helpers (=copy hooks, `state()` procs, `$` overloads,
+## `match` macros) inherit `CC = ccSingle` via the typestate macro's
+## `defaults:` body section (typestates 0.9.2+).
+##
+## ## States
+##
+## * `PinnedScopeAlive` — the scope holds a `Pinned[MT, CC]` value and is
+##   eligible for `retireOnCAS` / `retireOnPublish`.
+## * `PinnedScopeDestroyed` — terminal state reached via `=destroy`. The
+##   inner `Pinned` was moved out and driven to `Closed` through the
+##   `unpin` / `acknowledge` / `close` chain.
+##
+## ## Retire methods
+##
+## * `retireOnCAS` — atomically swap a published pointer, retire the
+##   displaced value. Multi-writer safe (the CAS arbitrates).
+## * `retireOnPublish` — store-and-retire. **FOOT-GUN: single-writer
+##   required (DR-S4).** nim-debra cannot statically verify that the caller's
+##   atomic is single-writer. Under multi-writer use, the displaced value
+##   may be retired concurrently and double-freed on reclamation. Use
+##   `retireOnCAS` for the multi-writer-safe form.
+##
+## ## Pitfalls
+##
+## * Do NOT call `pinScope` while the thread is already pinned at the slot
+##   level. A `doAssert` guards in release builds.
+## * `PinnedScope` is non-copyable (`=copy` is `{.error.}`). Move it
+##   between scopes if you must transfer ownership; the destructor runs
+##   exactly once at the final owner's scope end.
+## * `=wasMoved` marks the source as `consumed = true`; a re-entrant
+##   `=destroy` on a moved-from value is a no-op.
+##
+## ## See also
+##
+## * `debra/convenience.withPin`_ (deprecated) — the predecessor template.
+## * `debra/typestates/guard.pin`_ / `unpin`_ / `acknowledge`_ / `close`_ —
+##   the underlying `EpochGuardContext` transitions driven internally.
+## * `debra/typestates/retire`_ — `RetireReady` / `Retired` rotation used
+##   inside the retire methods.
+
+import ../atomics
+import ../types
+import ../limbo
+import ./cardinality
+import ./guard
+import ./retire
+import typestates
+
+export cardinality
+
+type
+  PinnedScopeContext*[MT: static int, CC: static PinScopeCardinality = ccSingle] = object of RootObj
+    # phantom-only base; the user-visible PinnedScope carries the live data.
+
+  PinnedScopeAlive*[MT: static int, CC: static PinScopeCardinality = ccSingle] =
+    distinct PinnedScopeContext[MT, CC]
+
+  PinnedScopeDestroyed*[MT: static int, CC: static PinScopeCardinality = ccSingle] =
+    distinct PinnedScopeContext[MT, CC]
+
+typestate PinnedScopeLifecycle[MT: static int, CC: static PinScopeCardinality]:
+  inheritsFromRootObj = true
+  defaults:
+    CC:
+      ccSingle
+  states:
+    PinnedScopeAlive[MT, CC]
+    PinnedScopeDestroyed[MT, CC]
+  initial:
+    PinnedScopeAlive[MT, CC]
+  terminal:
+    PinnedScopeDestroyed[MT, CC]
+  transitions:
+    PinnedScopeAlive[MT, CC] -> PinnedScopeDestroyed[MT, CC]
+
+type PinnedScope*[MT: static int, CC: static PinScopeCardinality = ccSingle] {.
+  PinnedScopeLifecycle: PinnedScopeAlive
+.} = object
+  state*: Pinned[MT, CC]
+  consumed*: bool
+
+proc pinScope*[MT: static int, CC: static PinScopeCardinality](
+    u: sink Unpinned[MT, CC]
+): PinnedScope[MT, CC] {.raises: [].} =
+  ## Construct a pinned scope. RAII-style: destruction unpins.
+  ##
+  ## Renamed from `pin` (the plan's original spelling) to `pinScope` to
+  ## avoid a proc-name collision with `guard.pin` (both consume
+  ## `Unpinned[MT, CC]` but return different result typestates, and Nim
+  ## cannot disambiguate by return type at standard call sites).
+  ##
+  ## ## Foot-gun: do NOT call `pinScope` while already pinned at the slot
+  ## level. A `doAssert` guards in release builds. Use `PinnedScope`
+  ## per-thread; the guard catches double-pin from re-entrant code.
+  runnableExamples:
+    import debra
+    var manager = initDebraManager[4]()
+    setGlobalManager(addr manager)
+    let handle = registerThread(manager)
+    block:
+      var scope = pinScope(unpinned(handle))
+      # scope is alive; on block exit =destroy runs and unpins.
+      discard scope.consumed
+
+  # NOTE: not marked {.transition.} — typestates 0.9.2 forbids cross-module
+  # transitions, and EpochGuardContext belongs to guard.nim. The inner
+  # u.pin() drives EpochGuardContext.Unpinned -> Pinned in-module. This
+  # outer constructor produces a value in PinnedScopeLifecycle's initial
+  # state PinnedScopeAlive via the
+  # {.PinnedScopeLifecycle: PinnedScopeAlive.} attachment pragma.
+  let handleVal = EpochGuardContext[MT, CC](u).handle
+  let idx = handleVal.idx
+  doAssert(
+    not handleVal.manager.threads[idx].pinned.load(moAcquire),
+    "pinScope: thread already pinned (re-entrant pin?)",
+  )
+  PinnedScope[MT, CC](state: u.pin(), consumed: false)
+
+proc retireOnCAS*[MT: static int, CC: static PinScopeCardinality, T](
+    scope: var PinnedScope[MT, CC],
+    atomic: var Atomic[T],
+    expected, desired: T,
+    dtor: Destructor,
+): bool {.discardable, raises: [].} =
+  ## Atomically swap a published pointer and retire the displaced value.
+  ##
+  ## Returns true on CAS success (after rotating `scope.state` through
+  ## `RetireReady` -> `Retired` -> `Pinned`). Returns false on CAS
+  ## failure, leaving `scope.state` unchanged.
+  ##
+  ## Callable under any `CC` (DR-S3).
+  var exp = expected
+  if atomic.compareExchange(exp, desired, moAcquireRelease, moAcquire):
+    # Rotate: Pinned -> RetireReady (BY-VALUE per DR-P3) -> Retired -> Pinned.
+    # retireReady is by-value over Pinned (does not consume scope.state in
+    # the typestate sense); the resulting RetireReady is the sink param for
+    # retire, which produces a fresh Retired. pinnedFromRetired rebuilds a
+    # Pinned in the same epoch so the scope remains usable for further
+    # retires inside the same pinned section.
+    var ready = retireReady(scope.state)
+    let retired = ready.retire(cast[pointer](exp), dtor)
+    scope.state = pinnedFromRetired(retired)
+    return true
+  return false
+
+proc retireOnPublish*[MT: static int, CC: static PinScopeCardinality, T](
+    scope: var PinnedScope[MT, CC], atomic: var Atomic[T], desired: T, dtor: Destructor
+) {.raises: [].} =
+  ## **FOOT-GUN — single-writer required (DR-S4).**
+  ##
+  ## Stores ``desired`` into ``atomic`` and retires the displaced value.
+  ## nim-debra cannot statically verify that ``atomic`` is single-writer;
+  ## under multi-writer use, the displaced value may be retired
+  ## concurrently and double-freed on reclamation.
+  ##
+  ## Use `retireOnCAS`_ for the multi-writer-safe form.
+  let displaced = atomic.load(moAcquire)
+  atomic.store(desired, moRelease)
+  var ready = retireReady(scope.state)
+  let retired = ready.retire(cast[pointer](displaced), dtor)
+  scope.state = pinnedFromRetired(retired)
+
+proc `=destroy`*[MT: static int, CC: static PinScopeCardinality](
+    scope: var PinnedScope[MT, CC]
+) {.destructorTransition: PinnedScopeAlive -> PinnedScopeDestroyed, raises: [].} =
+  ## Destructor: drives the inner `Pinned` through `unpin` (and, if the
+  ## thread was signaled, `acknowledge`) and finally `close`, clearing the
+  ## slot's `pinned` flag.
+  ##
+  ## A `=wasMoved`-marked scope (i.e. one whose value was moved into
+  ## another scope) is consumed; this destructor is a no-op for it.
+  if not scope.consumed:
+    var p = move(scope.state)
+    var res = p.unpin()
+    match res:
+      Unpinned(u):
+        discard u.close()
+      Neutralized(n):
+        discard n.acknowledge().close()
+
+proc `=copy`*[MT: static int, CC: static PinScopeCardinality](
+  dest: var PinnedScope[MT, CC], src: PinnedScope[MT, CC]
+) {.error.}
+
+proc `=wasMoved`*[MT: static int, CC: static PinScopeCardinality](
+    scope: var PinnedScope[MT, CC]
+) =
+  ## Mark the moved-from value as consumed so a re-entrant `=destroy` is a
+  ## no-op. Do NOT touch `scope.state`; the move source is unreachable by
+  ## the type system, and the destination owns the underlying `Pinned`.
+  scope.consumed = true

--- a/src/debra/typestates/pinned_scope.nim
+++ b/src/debra/typestates/pinned_scope.nim
@@ -144,6 +144,14 @@ proc retireOnCAS*[MT: static int, CC: static PinScopeCardinality, T](
   ## failure, leaving `scope.state` unchanged.
   ##
   ## Callable under any `CC` (DR-S3).
+  ##
+  ## **`T` contract:** `T` must be a raw pointer type (`ptr X` or
+  ## `pointer`). The displaced value is `cast[pointer]` and reclaimed via
+  ## `dtor`. Do NOT instantiate over a `ref` type: refs are GC-managed, so
+  ## retiring one and reclaiming it manually double-frees. The generic is
+  ## intentionally left unconstrained so downstream wrappers can forward
+  ## their own pointer-shaped element type; the constraint is a documented
+  ## caller contract, not a static bound.
   var exp = expected
   if atomic.compareExchange(exp, desired, moAcquireRelease, moAcquire):
     # Rotate: Pinned -> RetireReady (BY-VALUE per DR-P3) -> Retired -> Pinned.
@@ -169,6 +177,14 @@ proc retireOnPublish*[MT: static int, CC: static PinScopeCardinality, T](
   ## concurrently and double-freed on reclamation.
   ##
   ## Use `retireOnCAS`_ for the multi-writer-safe form.
+  ##
+  ## **`T` contract:** `T` must be a raw pointer type (`ptr X` or
+  ## `pointer`). The displaced value is `cast[pointer]` and reclaimed via
+  ## `dtor`. Do NOT instantiate over a `ref` type: refs are GC-managed, so
+  ## retiring one and reclaiming it manually double-frees. The generic is
+  ## intentionally left unconstrained so downstream wrappers can forward
+  ## their own pointer-shaped element type; the constraint is a documented
+  ## caller contract, not a static bound.
   # Single-writer fast path (DR-S4): the plain acquire-load + release-store is
   # deliberate and cheaper than an `exchange` RMW. Under the documented
   # single-writer contract no other thread writes `atomic`, so the loaded

--- a/src/debra/typestates/pinned_scope.nim
+++ b/src/debra/typestates/pinned_scope.nim
@@ -172,9 +172,11 @@ proc retireOnCAS*[MT: static int, CC: static PinScopeCardinality, T: ptr | point
     # retire, which produces a fresh Retired. pinnedFromRetired rebuilds a
     # Pinned in the same epoch so the scope remains usable for further
     # retires inside the same pinned section.
-    var ready = retireReady(scope.state)
-    let retired = ready.retire(cast[pointer](expected), dtor)
-    scope.state = pinnedFromRetired(retired)
+    let p = cast[pointer](expected)
+    if p != nil:
+      var ready = retireReady(scope.state)
+      let retired = ready.retire(p, dtor)
+      scope.state = pinnedFromRetired(retired)
     return true
   return false
 
@@ -205,9 +207,11 @@ proc retireOnPublish*[MT: static int, CC: static PinScopeCardinality, T: ptr | p
   # "hardened" variant of this foot-gun.
   let displaced = atomic.load(moAcquire)
   atomic.store(desired, moRelease)
-  var ready = retireReady(scope.state)
-  let retired = ready.retire(cast[pointer](displaced), dtor)
-  scope.state = pinnedFromRetired(retired)
+  let p = cast[pointer](displaced)
+  if p != nil:
+    var ready = retireReady(scope.state)
+    let retired = ready.retire(p, dtor)
+    scope.state = pinnedFromRetired(retired)
 
 proc `=destroy`*[MT: static int, CC: static PinScopeCardinality](
     scope: var PinnedScope[MT, CC]

--- a/src/debra/typestates/pinned_scope.nim
+++ b/src/debra/typestates/pinned_scope.nim
@@ -136,7 +136,7 @@ proc pinScope*[MT: static int, CC: static PinScopeCardinality](
   )
   PinnedScope[MT, CC](state: u.pin(), consumed: false)
 
-proc retireOnCAS*[MT: static int, CC: static PinScopeCardinality, T](
+proc retireOnCAS*[MT: static int, CC: static PinScopeCardinality, T: ptr | pointer](
     scope: var PinnedScope[MT, CC],
     atomic: var Atomic[T],
     expected: var T,
@@ -155,13 +155,12 @@ proc retireOnCAS*[MT: static int, CC: static PinScopeCardinality, T](
   ## value actually observed (as in stdlib `compareExchange`), so a retry
   ## loop need not re-load before the next attempt.
   ##
-  ## **`T` contract:** `T` must be a raw pointer type (`ptr X` or
-  ## `pointer`). The displaced value is `cast[pointer]` and reclaimed via
-  ## `dtor`. Do NOT instantiate over a `ref` type: refs are GC-managed, so
-  ## retiring one and reclaiming it manually double-frees. The generic is
-  ## intentionally left unconstrained so downstream wrappers can forward
-  ## their own pointer-shaped element type; the constraint is a documented
-  ## caller contract, not a static bound.
+  ## **`T` contract:** `T` is constrained to `ptr | pointer` (a raw pointer
+  ## type, `ptr X` or `pointer`). The displaced value is `cast[pointer]` and
+  ## reclaimed via `dtor`, so instantiating over a `ref` is rejected at
+  ## compile time — refs are GC-managed and would double-free on manual
+  ## reclamation. Generic wrappers forwarding their own element type must
+  ## likewise admit only pointer-shaped types.
   # `expected` is an in/out param (matches stdlib `compareExchange`): on CAS
   # failure `compareExchange` writes the observed value back into it so a
   # caller retry loop need not re-load. On success it is unchanged and still
@@ -179,7 +178,7 @@ proc retireOnCAS*[MT: static int, CC: static PinScopeCardinality, T](
     return true
   return false
 
-proc retireOnPublish*[MT: static int, CC: static PinScopeCardinality, T](
+proc retireOnPublish*[MT: static int, CC: static PinScopeCardinality, T: ptr | pointer](
     scope: var PinnedScope[MT, CC], atomic: var Atomic[T], desired: T, dtor: Destructor
 ) {.raises: [].} =
   ## **FOOT-GUN — single-writer required (DR-S4).**
@@ -191,13 +190,12 @@ proc retireOnPublish*[MT: static int, CC: static PinScopeCardinality, T](
   ##
   ## Use `retireOnCAS`_ for the multi-writer-safe form.
   ##
-  ## **`T` contract:** `T` must be a raw pointer type (`ptr X` or
-  ## `pointer`). The displaced value is `cast[pointer]` and reclaimed via
-  ## `dtor`. Do NOT instantiate over a `ref` type: refs are GC-managed, so
-  ## retiring one and reclaiming it manually double-frees. The generic is
-  ## intentionally left unconstrained so downstream wrappers can forward
-  ## their own pointer-shaped element type; the constraint is a documented
-  ## caller contract, not a static bound.
+  ## **`T` contract:** `T` is constrained to `ptr | pointer` (a raw pointer
+  ## type, `ptr X` or `pointer`). The displaced value is `cast[pointer]` and
+  ## reclaimed via `dtor`, so instantiating over a `ref` is rejected at
+  ## compile time — refs are GC-managed and would double-free on manual
+  ## reclamation. Generic wrappers forwarding their own element type must
+  ## likewise admit only pointer-shaped types.
   # Single-writer fast path (DR-S4): the plain acquire-load + release-store is
   # deliberate and cheaper than an `exchange` RMW. Under the documented
   # single-writer contract no other thread writes `atomic`, so the loaded

--- a/src/debra/typestates/pinned_scope.nim
+++ b/src/debra/typestates/pinned_scope.nim
@@ -1,7 +1,7 @@
 ## PinnedScope RAII guard for pin-scoped retire.
 ##
 ## `PinnedScope[MT, CC]` is the recommended high-level entry point for the
-## pin/retire/unpin cycle, replacing the deprecated `withPin` template.
+## pin/retire/unpin cycle, replacing the now-deprecated block-form sugar.
 ## Construct via `pinScope(unpinned(handle))`; destruction (block exit, scope
 ## end, explicit `=destroy`) drives the underlying `EpochGuardContext`
 ## through `unpin` (and, if signaled, `acknowledge`) and finally `close`,
@@ -48,7 +48,6 @@
 ##
 ## ## See also
 ##
-## * `debra/convenience.withPin`_ (deprecated) — the predecessor template.
 ## * `debra/typestates/guard.pin`_ / `unpin`_ / `acknowledge`_ / `close`_ —
 ##   the underlying `EpochGuardContext` transitions driven internally.
 ## * `debra/typestates/retire`_ — `RetireReady` / `Retired` rotation used

--- a/src/debra/typestates/pinned_scope.nim
+++ b/src/debra/typestates/pinned_scope.nim
@@ -169,6 +169,13 @@ proc retireOnPublish*[MT: static int, CC: static PinScopeCardinality, T](
   ## concurrently and double-freed on reclamation.
   ##
   ## Use `retireOnCAS`_ for the multi-writer-safe form.
+  # Single-writer fast path (DR-S4): the plain acquire-load + release-store is
+  # deliberate and cheaper than an `exchange` RMW. Under the documented
+  # single-writer contract no other thread writes `atomic`, so the loaded
+  # pointer is exactly the value the store displaces — an `exchange` would add
+  # a StoreLoad/RMW cost on this hot path for no benefit. Callers needing
+  # multi-writer safety must use `retireOnCAS` (the CAS form above), not a
+  # "hardened" variant of this foot-gun.
   let displaced = atomic.load(moAcquire)
   atomic.store(desired, moRelease)
   var ready = retireReady(scope.state)

--- a/src/debra/typestates/pinned_scope.nim
+++ b/src/debra/typestates/pinned_scope.nim
@@ -131,7 +131,7 @@ proc pinScope*[MT: static int, CC: static PinScopeCardinality](
   let handleVal = EpochGuardContext[MT, CC](u).handle
   let idx = handleVal.idx
   doAssert(
-    not handleVal.manager.threads[idx].pinned.load(moAcquire),
+    not handleVal.manager.threads[idx].pinned.load(moSequentiallyConsistent),
     "pinScope: thread already pinned (re-entrant pin?)",
   )
   PinnedScope[MT, CC](state: u.pin(), consumed: false)

--- a/src/debra/typestates/reclaim.nim
+++ b/src/debra/typestates/reclaim.nim
@@ -81,8 +81,8 @@ typestate ReclaimContext[MaxThreads: static int]:
     EpochsLoaded[MaxThreads] ->
       ReclaimReady[MaxThreads] | ReclaimBlocked[MaxThreads] as ReclaimCheck[MaxThreads]
 
-proc reclaimStart*[MaxThreads: static int](
-    handle: ThreadHandle[MaxThreads]
+proc reclaimStart*[MaxThreads: static int, CC: static PinScopeCardinality](
+    handle: ThreadHandle[MaxThreads, CC]
 ): ReclaimStart[MaxThreads] =
   ## Begin reclamation attempt for the calling thread's own retired objects.
   ##

--- a/src/debra/typestates/reclaim.nim
+++ b/src/debra/typestates/reclaim.nim
@@ -55,35 +55,45 @@ import ../limbo
 import ../signal
 
 type
-  ReclaimContext*[MaxThreads: static int] = object of RootObj
-    manager*: ptr DebraManager[MaxThreads]
+  ReclaimContext*[MaxThreads: static int, CC: static PinScopeCardinality = ccSingle] = object of RootObj
+    manager*: ptr DebraManager[MaxThreads, CC]
     idx*: int ## Slot index of the calling thread; bag walk targets this slot only.
     globalEpoch*: uint64
     safeEpoch*: uint64
 
-  ReclaimStart*[MaxThreads: static int] = distinct ReclaimContext[MaxThreads]
-  EpochsLoaded*[MaxThreads: static int] = distinct ReclaimContext[MaxThreads]
-  ReclaimReady*[MaxThreads: static int] = distinct ReclaimContext[MaxThreads]
-  ReclaimBlocked*[MaxThreads: static int] = distinct ReclaimContext[MaxThreads]
+  ReclaimStart*[MaxThreads: static int, CC: static PinScopeCardinality = ccSingle] =
+    distinct ReclaimContext[MaxThreads, CC]
+  EpochsLoaded*[MaxThreads: static int, CC: static PinScopeCardinality = ccSingle] =
+    distinct ReclaimContext[MaxThreads, CC]
+  ReclaimReady*[MaxThreads: static int, CC: static PinScopeCardinality = ccSingle] =
+    distinct ReclaimContext[MaxThreads, CC]
+  ReclaimBlocked*[MaxThreads: static int, CC: static PinScopeCardinality = ccSingle] =
+    distinct ReclaimContext[MaxThreads, CC]
 
-typestate ReclaimContext[MaxThreads: static int]:
+typestate ReclaimContext[MaxThreads: static int, CC: static PinScopeCardinality]:
   inheritsFromRootObj = true
   opaqueStates = true
-  states ReclaimStart[MaxThreads],
-    EpochsLoaded[MaxThreads], ReclaimReady[MaxThreads], ReclaimBlocked[MaxThreads]
+  defaults:
+    CC:
+      ccSingle
+  states ReclaimStart[MaxThreads, CC],
+    EpochsLoaded[MaxThreads, CC],
+    ReclaimReady[MaxThreads, CC],
+    ReclaimBlocked[MaxThreads, CC]
   initial:
-    ReclaimStart[MaxThreads]
+    ReclaimStart[MaxThreads, CC]
   terminal:
-    ReclaimReady[MaxThreads]
-    ReclaimBlocked[MaxThreads]
+    ReclaimReady[MaxThreads, CC]
+    ReclaimBlocked[MaxThreads, CC]
   transitions:
-    ReclaimStart[MaxThreads] -> EpochsLoaded[MaxThreads]
-    EpochsLoaded[MaxThreads] ->
-      ReclaimReady[MaxThreads] | ReclaimBlocked[MaxThreads] as ReclaimCheck[MaxThreads]
+    ReclaimStart[MaxThreads, CC] -> EpochsLoaded[MaxThreads, CC]
+    EpochsLoaded[MaxThreads, CC] ->
+      ReclaimReady[MaxThreads, CC] | ReclaimBlocked[MaxThreads, CC] as
+      ReclaimCheck[MaxThreads, CC]
 
 proc reclaimStart*[MaxThreads: static int, CC: static PinScopeCardinality](
     handle: ThreadHandle[MaxThreads, CC]
-): ReclaimStart[MaxThreads] =
+): ReclaimStart[MaxThreads, CC] =
   ## Begin reclamation attempt for the calling thread's own retired objects.
   ##
   ## `handle` identifies the slot whose limbo bag list will be walked. Pass the
@@ -92,15 +102,15 @@ proc reclaimStart*[MaxThreads: static int, CC: static PinScopeCardinality](
   ## without per-list synchronization.
   ##
   ## See also: `debra/convenience.reclaimNow`_ for the one-shot wrapper.
-  ReclaimStart[MaxThreads](
-    ReclaimContext[MaxThreads](
+  ReclaimStart[MaxThreads, CC](
+    ReclaimContext[MaxThreads, CC](
       manager: handle.manager, idx: handle.idx, globalEpoch: 0, safeEpoch: 0
     )
   )
 
-proc reclaimStart*[MaxThreads: static int](
-    mgr: ptr DebraManager[MaxThreads]
-): ReclaimStart[MaxThreads] =
+proc reclaimStart*[MaxThreads: static int, CC: static PinScopeCardinality = ccSingle](
+    mgr: ptr DebraManager[MaxThreads, CC]
+): ReclaimStart[MaxThreads, CC] =
   ## Legacy entry point that infers the calling thread's slot from the
   ## thread-local `threadLocalIdx` set by `registerThread`. Prefer the
   ## `reclaimStart(handle)` overload.
@@ -127,13 +137,13 @@ proc reclaimStart*[MaxThreads: static int](
       threadLocalIdx
     else:
       -1
-  ReclaimStart[MaxThreads](
-    ReclaimContext[MaxThreads](manager: mgr, idx: idx, globalEpoch: 0, safeEpoch: 0)
+  ReclaimStart[MaxThreads, CC](
+    ReclaimContext[MaxThreads, CC](manager: mgr, idx: idx, globalEpoch: 0, safeEpoch: 0)
   )
 
-proc loadEpochs*[MaxThreads: static int](
-    s: ReclaimStart[MaxThreads]
-): EpochsLoaded[MaxThreads] {.transition.} =
+proc loadEpochs*[MaxThreads: static int, CC: static PinScopeCardinality](
+    s: ReclaimStart[MaxThreads, CC]
+): EpochsLoaded[MaxThreads, CC] {.transition.} =
   ## Load global epoch and compute minimum epoch across pinned threads.
   ##
   ## Subscription read: an SC load of `globalEpoch` participates in the C11
@@ -183,7 +193,7 @@ proc loadEpochs*[MaxThreads: static int](
   # atomic" on the SC RMW below.
   subscribeBarrier.store(0'u64, moRelaxed)
   discard subscribeBarrier.fetchAdd(0'u64, moSequentiallyConsistent)
-  var ctx = ReclaimContext[MaxThreads](s)
+  var ctx = ReclaimContext[MaxThreads, CC](s)
   # `globalEpoch` is now just a value read; reading a slightly stale
   # epoch only makes `safeEpoch` conservatively lower, which is safe.
   # The acquire ordering is enough to pair with the release-stamping in
@@ -208,25 +218,25 @@ proc loadEpochs*[MaxThreads: static int](
       if threadEpoch < ctx.safeEpoch:
         ctx.safeEpoch = threadEpoch
 
-  result = EpochsLoaded[MaxThreads](ctx)
+  result = EpochsLoaded[MaxThreads, CC](ctx)
 
-func safeEpoch*[MaxThreads: static int](
-    e: EpochsLoaded[MaxThreads]
+func safeEpoch*[MaxThreads: static int, CC: static PinScopeCardinality](
+    e: EpochsLoaded[MaxThreads, CC]
 ): uint64 {.notATransition.} =
-  ReclaimContext[MaxThreads](e).safeEpoch
+  ReclaimContext[MaxThreads, CC](e).safeEpoch
 
-proc checkSafe*[MaxThreads: static int](
-    e: EpochsLoaded[MaxThreads]
-): ReclaimCheck[MaxThreads] {.transition.} =
+proc checkSafe*[MaxThreads: static int, CC: static PinScopeCardinality](
+    e: EpochsLoaded[MaxThreads, CC]
+): ReclaimCheck[MaxThreads, CC] {.transition.} =
   ## Check if any epochs are safe to reclaim.
-  let ctx = ReclaimContext[MaxThreads](e)
+  let ctx = ReclaimContext[MaxThreads, CC](e)
   if ctx.safeEpoch > 1:
-    ReclaimCheck[MaxThreads] -> ReclaimReady[MaxThreads](ctx)
+    ReclaimCheck[MaxThreads, CC] -> ReclaimReady[MaxThreads, CC](ctx)
   else:
-    ReclaimCheck[MaxThreads] -> ReclaimBlocked[MaxThreads](ctx)
+    ReclaimCheck[MaxThreads, CC] -> ReclaimBlocked[MaxThreads, CC](ctx)
 
-proc tryReclaim*[MaxThreads: static int](
-    r: ReclaimReady[MaxThreads]
+proc tryReclaim*[MaxThreads: static int, CC: static PinScopeCardinality](
+    r: ReclaimReady[MaxThreads, CC]
 ): int {.notATransition.} =
   ## Reclaim eligible objects from the calling thread's own limbo bag list.
   ##
@@ -249,7 +259,7 @@ proc tryReclaim*[MaxThreads: static int](
       ReclaimBlocked(_):
         # Brand-new manager: epoch hasn't advanced; this branch is normal.
         discard
-  let ctx = ReclaimContext[MaxThreads](r)
+  let ctx = ReclaimContext[MaxThreads, CC](r)
   if ctx.idx < 0 or ctx.idx >= MaxThreads:
     # Caller is not a registered thread; nothing to reclaim from their slot.
     return 0

--- a/src/debra/typestates/registration.nim
+++ b/src/debra/typestates/registration.nim
@@ -2,6 +2,18 @@
 ##
 ## Handles thread registration with the DEBRA manager, ensuring threads
 ## properly claim slots in the thread array using lock-free CAS operations.
+##
+## The typestate carries two static generic-param axes:
+##
+## - `MaxThreads: static int` — capacity of the manager's thread array.
+## - `CC: static PinScopeCardinality = ccSingle` — consumer-cardinality
+##   phantom mirroring `DebraManager` / `ThreadHandle`. Default `ccSingle`
+##   matches the 0.7.x call shape, so existing call sites that spell only
+##   `MaxThreads` continue to bind cleanly.
+##
+## Codegen-emitted helpers (variant type `RegisterResult`, `=copy` hooks,
+## `state()` procs, `$` overloads, `match` macros) inherit `CC = ccSingle`
+## via the typestate macro's `defaults:` body section (typestates 0.9.2+).
 
 import ../atomics
 import typestates
@@ -10,42 +22,59 @@ import ../types
 import ../signal
 import ../thread_id
 
+# `PinScopeCardinality` reaches this module via `../types` (re-exported
+# from `./cardinality`).
+
 type
-  RegistrationContext*[MaxThreads: static int] = object of RootObj
-    manager*: ptr DebraManager[MaxThreads]
+  RegistrationContext*[
+    MaxThreads: static int, CC: static PinScopeCardinality = ccSingle
+  ] = object of RootObj
+    manager*: ptr DebraManager[MaxThreads, CC]
     idx*: int
 
-  Unregistered*[MaxThreads: static int] = distinct RegistrationContext[MaxThreads]
-  Registered*[MaxThreads: static int] = distinct RegistrationContext[MaxThreads]
-  RegistrationFull*[MaxThreads: static int] = distinct RegistrationContext[MaxThreads]
+  Unregistered*[MaxThreads: static int, CC: static PinScopeCardinality = ccSingle] =
+    distinct RegistrationContext[MaxThreads, CC]
 
-typestate RegistrationContext[MaxThreads: static int]:
+  Registered*[MaxThreads: static int, CC: static PinScopeCardinality = ccSingle] =
+    distinct RegistrationContext[MaxThreads, CC]
+
+  RegistrationFull*[MaxThreads: static int, CC: static PinScopeCardinality = ccSingle] =
+    distinct RegistrationContext[MaxThreads, CC]
+
+typestate RegistrationContext[MaxThreads: static int, CC: static PinScopeCardinality]:
   inheritsFromRootObj = true
   opaqueStates = true
-  states Unregistered[MaxThreads], Registered[MaxThreads], RegistrationFull[MaxThreads]
+  defaults:
+    CC:
+      ccSingle
+  states:
+    Unregistered[MaxThreads, CC]
+    Registered[MaxThreads, CC]
+    RegistrationFull[MaxThreads, CC]
   initial:
-    Unregistered[MaxThreads]
+    Unregistered[MaxThreads, CC]
   terminal:
-    Registered[MaxThreads]
-    RegistrationFull[MaxThreads]
+    Registered[MaxThreads, CC]
+    RegistrationFull[MaxThreads, CC]
   transitions:
-    Unregistered[MaxThreads] ->
-      Registered[MaxThreads] | RegistrationFull[MaxThreads] as RegisterResult[
-        MaxThreads
-      ]
+    Unregistered[MaxThreads, CC] ->
+      Registered[MaxThreads, CC] | RegistrationFull[MaxThreads, CC] as
+      RegisterResult[MaxThreads, CC]
 
-proc unregistered*[MaxThreads: static int](
-    mgr: ptr DebraManager[MaxThreads]
-): Unregistered[MaxThreads] =
+proc unregistered*[MaxThreads: static int, CC: static PinScopeCardinality](
+    mgr: ptr DebraManager[MaxThreads, CC]
+): Unregistered[MaxThreads, CC] =
   ## Create unregistered context for a thread.
-  Unregistered[MaxThreads](RegistrationContext[MaxThreads](manager: mgr, idx: -1))
+  Unregistered[MaxThreads, CC](
+    RegistrationContext[MaxThreads, CC](manager: mgr, idx: -1)
+  )
 
-proc register*[MaxThreads: static int](
-    u: sink Unregistered[MaxThreads]
-): RegisterResult[MaxThreads] {.transition.} =
+proc register*[MaxThreads: static int, CC: static PinScopeCardinality](
+    u: sink Unregistered[MaxThreads, CC]
+): RegisterResult[MaxThreads, CC] {.transition.} =
   ## Try to register thread by claiming a slot. Returns Registered if successful,
   ## RegistrationFull if all slots are taken.
-  let ctx = RegistrationContext[MaxThreads](u)
+  let ctx = RegistrationContext[MaxThreads, CC](u)
   let mgr = ctx.manager
 
   # Try each slot in order
@@ -70,21 +99,27 @@ proc register*[MaxThreads: static int](
         threadLocalRegistered = true
         threadLocalManager = cast[pointer](mgr)
         return
-          RegisterResult[MaxThreads] ->
-          Registered[MaxThreads](RegistrationContext[MaxThreads](manager: mgr, idx: i))
+          RegisterResult[MaxThreads, CC] ->
+          Registered[MaxThreads, CC](
+            RegistrationContext[MaxThreads, CC](manager: mgr, idx: i)
+          )
       # CAS failed, expected was updated, retry with new value
 
   # All slots taken
-  RegisterResult[MaxThreads] ->
-    RegistrationFull[MaxThreads](RegistrationContext[MaxThreads](manager: mgr, idx: -1))
+  RegisterResult[MaxThreads, CC] ->
+    RegistrationFull[MaxThreads, CC](
+      RegistrationContext[MaxThreads, CC](manager: mgr, idx: -1)
+    )
 
-func idx*[MaxThreads: static int](r: Registered[MaxThreads]): int {.notATransition.} =
+func idx*[MaxThreads: static int, CC: static PinScopeCardinality](
+    r: Registered[MaxThreads, CC]
+): int {.notATransition.} =
   ## Get the thread slot index.
-  RegistrationContext[MaxThreads](r).idx
+  RegistrationContext[MaxThreads, CC](r).idx
 
-func getHandle*[MaxThreads: static int](
-    r: Registered[MaxThreads]
-): ThreadHandle[MaxThreads] =
+func getHandle*[MaxThreads: static int, CC: static PinScopeCardinality](
+    r: Registered[MaxThreads, CC]
+): ThreadHandle[MaxThreads, CC] =
   ## Extract ThreadHandle for use in pin/unpin operations.
-  let ctx = RegistrationContext[MaxThreads](r)
-  ThreadHandle[MaxThreads](idx: ctx.idx, manager: ctx.manager)
+  let ctx = RegistrationContext[MaxThreads, CC](r)
+  ThreadHandle[MaxThreads, CC](idx: ctx.idx, manager: ctx.manager)

--- a/src/debra/typestates/retire.nim
+++ b/src/debra/typestates/retire.nim
@@ -18,7 +18,9 @@
 ##
 ## ## See also
 ##
-## * `debra/convenience.withPin`_ + `it.retire(...)` - the recommended path.
+## * `debra/typestates/pinned_scope.PinnedScope`_ +
+##   `scope.retireOnCAS` / `scope.retireOnPublish` (or
+##   `retireReady(scope.state).retire(...)`) - the recommended path.
 ## * `debra/typestates/reclaim`_ - eventual reclamation after epoch safety.
 
 import typestates

--- a/src/debra/typestates/retire.nim
+++ b/src/debra/typestates/retire.nim
@@ -29,49 +29,57 @@ import ../limbo
 import ./guard
 
 type
-  RetireContext*[MaxThreads: static int] = object of RootObj
-    handle*: ThreadHandle[MaxThreads]
+  RetireContext*[MaxThreads: static int, CC: static PinScopeCardinality = ccSingle] = object of RootObj
+    handle*: ThreadHandle[MaxThreads, CC]
     epoch*: uint64
 
-  RetireReady*[MaxThreads: static int] = distinct RetireContext[MaxThreads]
-  Retired*[MaxThreads: static int] = distinct RetireContext[MaxThreads]
+  RetireReady*[MaxThreads: static int, CC: static PinScopeCardinality = ccSingle] =
+    distinct RetireContext[MaxThreads, CC]
 
-typestate RetireContext[MaxThreads: static int]:
+  Retired*[MaxThreads: static int, CC: static PinScopeCardinality = ccSingle] =
+    distinct RetireContext[MaxThreads, CC]
+
+typestate RetireContext[MaxThreads: static int, CC: static PinScopeCardinality]:
   inheritsFromRootObj = true
   opaqueStates = true
-  states RetireReady[MaxThreads], Retired[MaxThreads]
+  defaults:
+    CC:
+      ccSingle
+  states RetireReady[MaxThreads, CC], Retired[MaxThreads, CC]
   initial:
-    RetireReady[MaxThreads]
+    RetireReady[MaxThreads, CC]
   terminal:
-    Retired[MaxThreads]
+    Retired[MaxThreads, CC]
   transitions:
-    RetireReady[MaxThreads] -> Retired[MaxThreads]
+    RetireReady[MaxThreads, CC] -> Retired[MaxThreads, CC]
 
-proc retireReady*[MaxThreads: static int](
-    p: Pinned[MaxThreads]
-): RetireReady[MaxThreads] =
+proc retireReady*[MaxThreads: static int, CC: static PinScopeCardinality](
+    p: Pinned[MaxThreads, CC]
+): RetireReady[MaxThreads, CC] =
   ## Create retire context from pinned state.
-  RetireReady[MaxThreads](RetireContext[MaxThreads](handle: p.handle, epoch: p.epoch))
+  RetireReady[MaxThreads, CC](
+    RetireContext[MaxThreads, CC](handle: p.handle, epoch: p.epoch)
+  )
 
-proc retireReadyFromRetired*[MaxThreads: static int](
-    r: sink Retired[MaxThreads]
-): RetireReady[MaxThreads] =
+proc retireReadyFromRetired*[MaxThreads: static int, CC: static PinScopeCardinality](
+    r: sink Retired[MaxThreads, CC]
+): RetireReady[MaxThreads, CC] =
   ## Get back to RetireReady after retiring (for multiple retires).
-  RetireReady[MaxThreads](RetireContext[MaxThreads](r))
+  RetireReady[MaxThreads, CC](RetireContext[MaxThreads, CC](r))
 
-proc pinnedFromRetired*[MaxThreads: static int](
-    r: sink Retired[MaxThreads]
-): Pinned[MaxThreads] =
-  ## Return a `Pinned[MaxThreads]` reconstructed from a `Retired[MaxThreads]`
-  ## value, allowing the caller to keep working in the same pinned epoch
-  ## (e.g. interleaving reads with further retires) instead of unpinning
-  ## immediately after a retire.
+proc pinnedFromRetired*[MaxThreads: static int, CC: static PinScopeCardinality](
+    r: sink Retired[MaxThreads, CC]
+): Pinned[MaxThreads, CC] =
+  ## Return a `Pinned[MaxThreads, CC]` reconstructed from a
+  ## `Retired[MaxThreads, CC]` value, allowing the caller to keep working
+  ## in the same pinned epoch (e.g. interleaving reads with further
+  ## retires) instead of unpinning immediately after a retire.
   ##
   ## Symmetric to `retireReadyFromRetired`: same underlying
-  ## `RetireContext[MaxThreads]`, projected to the `Pinned` typestate via
-  ## the `EpochGuardContext[MaxThreads]` shape (handle + epoch). The slot's
-  ## `pinned` flag is unchanged; this is a typestate rebrand, not a
-  ## re-pin.
+  ## `RetireContext[MaxThreads, CC]`, projected to the `Pinned` typestate
+  ## via the `EpochGuardContext[MaxThreads, CC]` shape (handle + epoch).
+  ## The slot's `pinned` flag is unchanged; this is a typestate rebrand,
+  ## not a re-pin.
   ##
   ## See also: `retireReadyFromRetired`_, `retire`_, `debra/typestates/guard.pin`_.
   runnableExamples:
@@ -91,14 +99,14 @@ proc pinnedFromRetired*[MaxThreads: static int](
     let pinnedAgain = pinnedFromRetired(retired)
     discard pinnedAgain.unpin()
 
-  let ctx = RetireContext[MaxThreads](r)
-  Pinned[MaxThreads](
-    EpochGuardContext[MaxThreads](handle: ctx.handle, epoch: ctx.epoch)
+  let ctx = RetireContext[MaxThreads, CC](r)
+  Pinned[MaxThreads, CC](
+    EpochGuardContext[MaxThreads, CC](handle: ctx.handle, epoch: ctx.epoch)
   )
 
-proc retire*[MaxThreads: static int](
-    r: sink RetireReady[MaxThreads], p: pointer, destructor: Destructor
-): Retired[MaxThreads] {.transition.} =
+proc retire*[MaxThreads: static int, CC: static PinScopeCardinality](
+    r: sink RetireReady[MaxThreads, CC], p: pointer, destructor: Destructor
+): Retired[MaxThreads, CC] {.transition.} =
   ## Retire a raw pointer for epoch-based reclamation.
   ##
   ## The destructor will be called when the epoch becomes safe.
@@ -118,7 +126,7 @@ proc retire*[MaxThreads: static int](
     discard pinnedAgain.unpin()
 
   # Extract values we need before consuming r
-  let handle = RetireContext[MaxThreads](r).handle
+  let handle = RetireContext[MaxThreads, CC](r).handle
   let state = addr handle.manager.threads[handle.idx]
 
   # Record the CURRENT global epoch as the bag's epoch, not the pin's
@@ -192,9 +200,9 @@ proc retire*[MaxThreads: static int](
   inc bag.count
 
   # Consume r to create result
-  Retired[MaxThreads](RetireContext[MaxThreads](r))
+  Retired[MaxThreads, CC](RetireContext[MaxThreads, CC](r))
 
-func handle*[MaxThreads: static int](
-    r: RetireReady[MaxThreads]
-): ThreadHandle[MaxThreads] =
-  RetireContext[MaxThreads](r).handle
+func handle*[MaxThreads: static int, CC: static PinScopeCardinality](
+    r: RetireReady[MaxThreads, CC]
+): ThreadHandle[MaxThreads, CC] {.notATransition.} =
+  RetireContext[MaxThreads, CC](r).handle

--- a/src/debra/typestates/retire.nim
+++ b/src/debra/typestates/retire.nim
@@ -65,13 +65,13 @@ proc retireReady*[MaxThreads: static int, CC: static PinScopeCardinality](
 
 proc retireReadyFromRetired*[MaxThreads: static int, CC: static PinScopeCardinality](
     r: sink Retired[MaxThreads, CC]
-): RetireReady[MaxThreads, CC] =
+): RetireReady[MaxThreads, CC] {.notATransition.} =
   ## Get back to RetireReady after retiring (for multiple retires).
   RetireReady[MaxThreads, CC](RetireContext[MaxThreads, CC](r))
 
 proc pinnedFromRetired*[MaxThreads: static int, CC: static PinScopeCardinality](
     r: sink Retired[MaxThreads, CC]
-): Pinned[MaxThreads, CC] =
+): Pinned[MaxThreads, CC] {.notATransition.} =
   ## Return a `Pinned[MaxThreads, CC]` reconstructed from a
   ## `Retired[MaxThreads, CC]` value, allowing the caller to keep working
   ## in the same pinned epoch (e.g. interleaving reads with further

--- a/src/debra/typestates/slot.nim
+++ b/src/debra/typestates/slot.nim
@@ -12,74 +12,85 @@ import typestates
 import ../types
 
 type
-  SlotContext*[MaxThreads: static int] = object of RootObj
+  SlotContext*[MaxThreads: static int, CC: static PinScopeCardinality = ccSingle] = object of RootObj
     idx*: int
-    manager*: ptr DebraManager[MaxThreads]
+    manager*: ptr DebraManager[MaxThreads, CC]
 
-  Free*[MaxThreads: static int] = distinct SlotContext[MaxThreads]
-  Claiming*[MaxThreads: static int] = distinct SlotContext[MaxThreads]
-  Active*[MaxThreads: static int] = distinct SlotContext[MaxThreads]
-  Draining*[MaxThreads: static int] = distinct SlotContext[MaxThreads]
+  Free*[MaxThreads: static int, CC: static PinScopeCardinality = ccSingle] =
+    distinct SlotContext[MaxThreads, CC]
+  Claiming*[MaxThreads: static int, CC: static PinScopeCardinality = ccSingle] =
+    distinct SlotContext[MaxThreads, CC]
+  Active*[MaxThreads: static int, CC: static PinScopeCardinality = ccSingle] =
+    distinct SlotContext[MaxThreads, CC]
+  Draining*[MaxThreads: static int, CC: static PinScopeCardinality = ccSingle] =
+    distinct SlotContext[MaxThreads, CC]
 
-typestate SlotContext[MaxThreads: static int]:
+typestate SlotContext[MaxThreads: static int, CC: static PinScopeCardinality]:
   inheritsFromRootObj = true
-  states Free[MaxThreads],
-    Claiming[MaxThreads], Active[MaxThreads], Draining[MaxThreads]
+  defaults:
+    CC:
+      ccSingle
+  states Free[MaxThreads, CC],
+    Claiming[MaxThreads, CC], Active[MaxThreads, CC], Draining[MaxThreads, CC]
   transitions:
-    Free[MaxThreads] -> Claiming[MaxThreads]
-    Claiming[MaxThreads] -> Active[MaxThreads]
-    Active[MaxThreads] -> Draining[MaxThreads]
-    Draining[MaxThreads] -> Free[MaxThreads]
+    Free[MaxThreads, CC] -> Claiming[MaxThreads, CC]
+    Claiming[MaxThreads, CC] -> Active[MaxThreads, CC]
+    Active[MaxThreads, CC] -> Draining[MaxThreads, CC]
+    Draining[MaxThreads, CC] -> Free[MaxThreads, CC]
 
-proc freeSlot*[MaxThreads: static int](
-    idx: int, mgr: ptr DebraManager[MaxThreads]
-): Free[MaxThreads] =
+proc freeSlot*[MaxThreads: static int, CC: static PinScopeCardinality = ccSingle](
+    idx: int, mgr: ptr DebraManager[MaxThreads, CC]
+): Free[MaxThreads, CC] =
   ## Create a free slot context.
-  Free[MaxThreads](SlotContext[MaxThreads](idx: idx, manager: mgr))
+  Free[MaxThreads, CC](SlotContext[MaxThreads, CC](idx: idx, manager: mgr))
 
-proc claim*[MaxThreads: static int](
-    f: sink Free[MaxThreads]
-): Claiming[MaxThreads] {.transition.} =
+proc claim*[MaxThreads: static int, CC: static PinScopeCardinality](
+    f: sink Free[MaxThreads, CC]
+): Claiming[MaxThreads, CC] {.transition.} =
   ## Begin claiming this slot. Transition to Claiming state.
-  Claiming[MaxThreads](SlotContext[MaxThreads](f))
+  Claiming[MaxThreads, CC](SlotContext[MaxThreads, CC](f))
 
-proc activate*[MaxThreads: static int](
-    c: sink Claiming[MaxThreads]
-): Active[MaxThreads] {.transition.} =
+proc activate*[MaxThreads: static int, CC: static PinScopeCardinality](
+    c: sink Claiming[MaxThreads, CC]
+): Active[MaxThreads, CC] {.transition.} =
   ## Complete slot claim. Transition to Active state.
   ## This is where the slot becomes fully owned by a thread.
-  Active[MaxThreads](SlotContext[MaxThreads](c))
+  Active[MaxThreads, CC](SlotContext[MaxThreads, CC](c))
 
-proc drain*[MaxThreads: static int](
-    a: sink Active[MaxThreads]
-): Draining[MaxThreads] {.transition.} =
+proc drain*[MaxThreads: static int, CC: static PinScopeCardinality](
+    a: sink Active[MaxThreads, CC]
+): Draining[MaxThreads, CC] {.transition.} =
   ## Begin unregistration. Transition to Draining state.
   ## Thread will drain its limbo bags before releasing the slot.
-  Draining[MaxThreads](SlotContext[MaxThreads](a))
+  Draining[MaxThreads, CC](SlotContext[MaxThreads, CC](a))
 
-proc release*[MaxThreads: static int](
-    d: sink Draining[MaxThreads]
-): Free[MaxThreads] {.transition.} =
+proc release*[MaxThreads: static int, CC: static PinScopeCardinality](
+    d: sink Draining[MaxThreads, CC]
+): Free[MaxThreads, CC] {.transition.} =
   ## Release slot back to free pool. Transition back to Free state.
   ## This completes the lifecycle, making the slot available for reuse.
-  Free[MaxThreads](SlotContext[MaxThreads](d))
+  Free[MaxThreads, CC](SlotContext[MaxThreads, CC](d))
 
-func idx*[MaxThreads: static int](s: Active[MaxThreads]): int {.notATransition.} =
+func idx*[MaxThreads: static int, CC: static PinScopeCardinality](
+    s: Active[MaxThreads, CC]
+): int {.notATransition.} =
   ## Get the slot index from Active state.
-  SlotContext[MaxThreads](s).idx
+  SlotContext[MaxThreads, CC](s).idx
 
-func idx*[MaxThreads: static int](s: Draining[MaxThreads]): int {.notATransition.} =
+func idx*[MaxThreads: static int, CC: static PinScopeCardinality](
+    s: Draining[MaxThreads, CC]
+): int {.notATransition.} =
   ## Get the slot index from Draining state.
-  SlotContext[MaxThreads](s).idx
+  SlotContext[MaxThreads, CC](s).idx
 
-func manager*[MaxThreads: static int](
-    s: Active[MaxThreads]
-): ptr DebraManager[MaxThreads] =
+func manager*[MaxThreads: static int, CC: static PinScopeCardinality](
+    s: Active[MaxThreads, CC]
+): ptr DebraManager[MaxThreads, CC] =
   ## Get the manager pointer from Active state.
-  SlotContext[MaxThreads](s).manager
+  SlotContext[MaxThreads, CC](s).manager
 
-func manager*[MaxThreads: static int](
-    s: Draining[MaxThreads]
-): ptr DebraManager[MaxThreads] =
+func manager*[MaxThreads: static int, CC: static PinScopeCardinality](
+    s: Draining[MaxThreads, CC]
+): ptr DebraManager[MaxThreads, CC] =
   ## Get the manager pointer from Draining state.
-  SlotContext[MaxThreads](s).manager
+  SlotContext[MaxThreads, CC](s).manager

--- a/src/debra/typestates/slot.nim
+++ b/src/debra/typestates/slot.nim
@@ -85,12 +85,12 @@ func idx*[MaxThreads: static int, CC: static PinScopeCardinality](
 
 func manager*[MaxThreads: static int, CC: static PinScopeCardinality](
     s: Active[MaxThreads, CC]
-): ptr DebraManager[MaxThreads, CC] =
+): ptr DebraManager[MaxThreads, CC] {.notATransition.} =
   ## Get the manager pointer from Active state.
   SlotContext[MaxThreads, CC](s).manager
 
 func manager*[MaxThreads: static int, CC: static PinScopeCardinality](
     s: Draining[MaxThreads, CC]
-): ptr DebraManager[MaxThreads, CC] =
+): ptr DebraManager[MaxThreads, CC] {.notATransition.} =
   ## Get the manager pointer from Draining state.
   SlotContext[MaxThreads, CC](s).manager

--- a/tests/should_fail/cfg_terminal_not_reached_negative.nim
+++ b/tests/should_fail/cfg_terminal_not_reached_negative.nim
@@ -44,9 +44,9 @@ proc step1*[N: static int](s: sink Start[N]): Middle[N] {.transition, raises: []
 proc step2*[N: static int](m: sink Middle[N]): Done[N] {.transition, raises: [].} =
   Done[N](MyFSM[N](m))
 
-proc badEarlyReturn*[N: static int](s: sink Start[N], flag: bool): Middle[N] {.
-  transition, raises: []
-.} =
+proc badEarlyReturn*[N: static int](
+    s: sink Start[N], flag: bool
+): Middle[N] {.transition, raises: [].} =
   ## The body-local `m: Middle[N]` is non-terminal at the early return
   ## on the `flag=true` branch — CFG-001 fires there.
   var m {.used.}: Middle[N]

--- a/tests/should_fail/cfg_terminal_not_reached_negative.nim
+++ b/tests/should_fail/cfg_terminal_not_reached_negative.nim
@@ -1,0 +1,59 @@
+## Self-contained CFG-analyzer fixture (negative case).
+##
+## Demonstrates the typestates 0.9.0+ CFG analyzer rejects a proc where
+## at least one exit path leaves a typestate-bearing local in a
+## non-terminal state.
+##
+## Must NOT compile. The runner pins the substring
+## "has not reached a terminal state at this return" — typestates'
+## `validateExitEdge` (verify.nim) emits this message when a tracked
+## local hasn't been driven to a terminal state by the exit edge and
+## no destructorTransition is registered for its current state.
+##
+## See cfg_terminal_not_reached_positive.nim for the rationale behind
+## using a local fixture instead of nim-debra's EBR typestates.
+
+import typestates
+
+type
+  MyFSM*[N: static int] = object of RootObj
+
+  Start*[N: static int] = distinct MyFSM[N]
+  Middle*[N: static int] = distinct MyFSM[N]
+  Done*[N: static int] = distinct MyFSM[N]
+
+typestate MyFSM[N: static int]:
+  inheritsFromRootObj = true
+  consumeOnTransition = false
+  strictTransitions = false
+  states:
+    Start[N]
+    Middle[N]
+    Done[N]
+  initial:
+    Start[N]
+  terminal:
+    Done[N]
+  transitions:
+    Start[N] -> Middle[N]
+    Middle[N] -> Done[N]
+
+proc step1*[N: static int](s: sink Start[N]): Middle[N] {.transition, raises: [].} =
+  Middle[N](MyFSM[N](s))
+
+proc step2*[N: static int](m: sink Middle[N]): Done[N] {.transition, raises: [].} =
+  Done[N](MyFSM[N](m))
+
+proc badEarlyReturn*[N: static int](s: sink Start[N], flag: bool): Middle[N] {.
+  transition, raises: []
+.} =
+  ## The body-local `m: Middle[N]` is non-terminal at the early return
+  ## on the `flag=true` branch — CFG-001 fires there.
+  var m {.used.}: Middle[N]
+  if flag:
+    result = step1(s)
+    return # m: Middle[N] non-terminal at this return
+  result = step1(s)
+  m = step2(result).Middle[N]
+
+verifyTypestates()

--- a/tests/should_fail/cfg_terminal_not_reached_positive.nim
+++ b/tests/should_fail/cfg_terminal_not_reached_positive.nim
@@ -1,0 +1,54 @@
+## Self-contained CFG-analyzer fixture (positive case).
+##
+## Demonstrates the typestates 0.9.0+ CFG analyzer accepts a proc where
+## every exit path reaches a terminal state.
+##
+## The fixture is local to this test file because typestates only walks
+## `{.transition.}`-registered procs declared in the typestate's home
+## module. nim-debra's EBR typestates live in nim-debra's source
+## modules, so user test code cannot register transitions against
+## them. The MyFSM typestate below mirrors typestates' own
+## `tests/should_fail/pragmas/cfg_analyzer_early_return_misses_terminal.nim`
+## fixture shape.
+##
+## Must `nim c` cleanly.
+
+import typestates
+
+type
+  MyFSM*[N: static int] = object of RootObj
+
+  Start*[N: static int] = distinct MyFSM[N]
+  Middle*[N: static int] = distinct MyFSM[N]
+  Done*[N: static int] = distinct MyFSM[N]
+
+typestate MyFSM[N: static int]:
+  inheritsFromRootObj = true
+  consumeOnTransition = false
+  strictTransitions = false
+  states:
+    Start[N]
+    Middle[N]
+    Done[N]
+  initial:
+    Start[N]
+  terminal:
+    Done[N]
+  transitions:
+    Start[N] -> Middle[N]
+    Middle[N] -> Done[N]
+
+proc step1*[N: static int](s: sink Start[N]): Middle[N] {.transition, raises: [].} =
+  Middle[N](MyFSM[N](s))
+
+proc step2*[N: static int](m: sink Middle[N]): Done[N] {.transition, raises: [].} =
+  Done[N](MyFSM[N](m))
+
+proc good*[N: static int](m: sink Middle[N], flag: bool): Done[N] {.transition, raises: [].} =
+  ## Every exit returns a Done value; the CFG analyzer accepts.
+  if flag:
+    result = step2(m)
+    return
+  result = step2(m)
+
+verifyTypestates()

--- a/tests/should_fail/cfg_terminal_not_reached_positive.nim
+++ b/tests/should_fail/cfg_terminal_not_reached_positive.nim
@@ -44,7 +44,9 @@ proc step1*[N: static int](s: sink Start[N]): Middle[N] {.transition, raises: []
 proc step2*[N: static int](m: sink Middle[N]): Done[N] {.transition, raises: [].} =
   Done[N](MyFSM[N](m))
 
-proc good*[N: static int](m: sink Middle[N], flag: bool): Done[N] {.transition, raises: [].} =
+proc good*[N: static int](
+    m: sink Middle[N], flag: bool
+): Done[N] {.transition, raises: [].} =
   ## Every exit returns a Done value; the CFG analyzer accepts.
   if flag:
     result = step2(m)

--- a/tests/should_fail/runner.nim
+++ b/tests/should_fail/runner.nim
@@ -52,6 +52,12 @@ const cases = @[
     outcome: eoCompileFails,
     substring: "'=copy' is not available for type",
   ),
+  Case(
+    name: "retireOnCAS non-pointer T rejected (must fail-with-substring)",
+    file: "tests/should_fail/t_retire_nonptr_rejected.nim",
+    outcome: eoCompileFails,
+    substring: "T: ptr | pointer",
+  ),
 ]
 
 proc runCase(c: Case): bool =

--- a/tests/should_fail/runner.nim
+++ b/tests/should_fail/runner.nim
@@ -1,0 +1,93 @@
+## Driver for nim-debra's compile-fail test suite.
+##
+## Each entry asserts (a) the expected exit status from `nim c` (zero
+## for positive cases, non-zero for negative cases) and (b) that the
+## compiler's combined stdout+stderr contains a pinned error-message
+## substring specific to the failure mode under test.
+##
+## Pinning the substring (rather than just the exit status) guards
+## against silent regressions where the compile-fail still happens but
+## the underlying check has rotted — e.g., a future typestates release
+## that drops the CFG-analyzer terminal-not-reached gate, or a Nim
+## release that renames the `=copy` error template.
+##
+## The CFG-analyzer negative test uses a local-fixture typestate
+## (MyFSM) because typestates 0.9.2 only walks `{.transition.}`-
+## registered procs, and `{.transition.}` must live in the
+## typestate's home module. The fixture's home module IS the test
+## file, so the analyzer walks `badEarlyReturn` and rejects it.
+## This guards against future typestates releases weakening the
+## CFG-analyzer soundness gate (analyzer removed, substring rotated,
+## walk-coverage shrunk).
+
+import std/[os, osproc, strformat, strutils]
+
+type
+  ExpectedOutcome = enum
+    eoCompiles # `nim c` must exit 0; no substring needed.
+    eoCompileFails # `nim c` must exit non-zero; substring must appear.
+
+  Case = object
+    name: string
+    file: string
+    outcome: ExpectedOutcome
+    substring: string
+
+const cases = @[
+  Case(
+    name: "cfg-terminal-not-reached positive (must compile)",
+    file: "tests/should_fail/cfg_terminal_not_reached_positive.nim",
+    outcome: eoCompiles,
+    substring: "",
+  ),
+  Case(
+    name: "cfg-terminal-not-reached negative (must fail-with-substring)",
+    file: "tests/should_fail/cfg_terminal_not_reached_negative.nim",
+    outcome: eoCompileFails,
+    substring: "has not reached a terminal state at this return",
+  ),
+  Case(
+    name: "pinned-scope =copy (must fail-with-substring)",
+    file: "tests/should_fail/t_pinned_scope_copy.nim",
+    outcome: eoCompileFails,
+    substring: "'=copy' is not available for type",
+  ),
+]
+
+proc runCase(c: Case): bool =
+  let cmd =
+    &"nim c --threads:on --hints:off --warnings:off --path:src --compileOnly {c.file}"
+  let (output, exitCode) = execCmdEx(cmd)
+  case c.outcome
+  of eoCompiles:
+    if exitCode != 0:
+      echo &"[FAIL] {c.name}: expected exit 0, got {exitCode}"
+      echo output
+      return false
+    echo &"[PASS] {c.name}"
+    return true
+  of eoCompileFails:
+    if exitCode == 0:
+      echo &"[FAIL] {c.name}: expected non-zero exit, got 0 (unexpected success)"
+      echo output
+      return false
+    if not output.contains(c.substring):
+      echo &"[FAIL] {c.name}: substring not found"
+      echo &"       expected substring: {c.substring}"
+      echo "       actual output:"
+      echo output
+      return false
+    echo &"[PASS] {c.name} (exit {exitCode}, substring matched)"
+    return true
+
+proc main() =
+  var failed = 0
+  for c in cases:
+    if not runCase(c):
+      inc failed
+  if failed > 0:
+    echo &"\n{failed} compile-fail case(s) failed."
+    quit(1)
+  echo &"\nAll {cases.len} compile-fail cases passed."
+
+main()

--- a/tests/should_fail/t_pinned_scope_copy.nim
+++ b/tests/should_fail/t_pinned_scope_copy.nim
@@ -1,0 +1,22 @@
+## Compile-fail test: copying a PinnedScope must fail.
+##
+## `pinned_scope.nim` declares `{.error.}` on `=copy`. The runner
+## verifies this by invoking `nim c` and asserting the substring
+## "'=copy' is not available for type" appears in the compiler's
+## error output.
+##
+## A copy is forced by reading `a` after the assignment so the
+## compiler cannot rewrite `var b = a` as a move.
+
+import debra
+
+proc main =
+  var manager = initDebraManager[4]()
+  setGlobalManager(addr manager)
+  let handle = registerThread(manager)
+  var a = pinScope(unpinned(handle))
+  var b = a
+  discard a # force a real copy, not a sink-driven move
+  discard b
+
+main()

--- a/tests/should_fail/t_pinned_scope_copy.nim
+++ b/tests/should_fail/t_pinned_scope_copy.nim
@@ -10,7 +10,7 @@
 
 import debra
 
-proc main =
+proc main() =
   var manager = initDebraManager[4]()
   setGlobalManager(addr manager)
   let handle = registerThread(manager)

--- a/tests/should_fail/t_retire_nonptr_rejected.nim
+++ b/tests/should_fail/t_retire_nonptr_rejected.nim
@@ -1,0 +1,30 @@
+## Compile-fail test: retireOnCAS must reject a non-pointer element type.
+##
+## `pinned_scope.nim` constrains `retireOnCAS`'s generic `T` to
+## `ptr | pointer`. Only raw pointer types are sound: the displaced value is
+## `cast[pointer]` and reclaimed via `dtor`, so a GC-managed `ref` (or any
+## non-pointer type) must be rejected at compile time rather than only by
+## documentation. A `ref` element type is independently rejected earlier by
+## `Atomic[ref T]`, so this case exercises the `retireOnCAS` constraint
+## directly with a non-pointer scalar (`int`) that `Atomic` itself accepts.
+## The runner verifies the constraint by invoking `nim c` and asserting the
+## constraint-failure substring appears in the compiler's error output.
+
+import debra
+import debra/atomics
+
+proc dtor(p: pointer) {.nimcall.} =
+  dealloc(p)
+
+proc main() =
+  var manager = initDebraManager[4]()
+  setGlobalManager(addr manager)
+  let handle = registerThread(manager)
+
+  var slot: Atomic[int] # non-pointer element type: violates T: ptr | pointer
+  var scope = pinScope(unpinned(handle))
+  var exp = slot.load(moAcquire)
+  # T inferred as `int`, violating the `T: ptr | pointer` constraint.
+  discard scope.retireOnCAS(slot, exp, 42, dtor)
+
+main()

--- a/tests/t_advance.nim
+++ b/tests/t_advance.nim
@@ -5,7 +5,7 @@ import debra/types
 import debra/typestates/advance
 
 suite "EpochAdvance typestate":
-  var mgr: DebraManager[4]
+  var mgr: DebraManager[4, ccSingle]
 
   setup:
     mgr = initDebraManager[4]()

--- a/tests/t_convenience.nim
+++ b/tests/t_convenience.nim
@@ -79,17 +79,19 @@ suite "DEBRA Batched Retire/Reclaim API":
     let handle = registerThread(manager)
     destroyedCount = 0
 
-  test "withPin injects it and retires multiple pointers":
+  test "pinScope injects scope.state and retires multiple pointers":
     let n1 = cast[Node](alloc0(sizeof(NodeObj)))
     let n2 = cast[Node](alloc0(sizeof(NodeObj)))
     let n3 = cast[Node](alloc0(sizeof(NodeObj)))
 
-    handle.withPin:
-      it.retire(n1, destroyNode)
-      it.retire(n2, destroyNode)
-      it.retire(n3, destroyNode)
+    block:
+      var scope = pinScope(unpinned(handle))
+      var ready = retireReady(scope.state)
+      ready.retire(n1, destroyNode)
+      ready.retire(n2, destroyNode)
+      ready.retire(n3, destroyNode)
 
-    # Thread is unpinned after the body
+    # Thread is unpinned after the scope's =destroy
     check not manager.threads[handle.idx].pinned.load(moAcquire)
 
     # Advance epoch and reclaim
@@ -99,10 +101,12 @@ suite "DEBRA Batched Retire/Reclaim API":
     discard reclaimNow(manager)
     check destroyedCount == 3
 
-  test "withPin accepts a custom identifier":
+  test "pinScope retires a single pointer via retireReady":
     let n = cast[Node](alloc0(sizeof(NodeObj)))
 
-    handle.withPin(myPin):
+    block:
+      var scope = pinScope(unpinned(handle))
+      var myPin = retireReady(scope.state)
       myPin.retire(n, destroyNode)
 
     check not manager.threads[handle.idx].pinned.load(moAcquire)
@@ -112,23 +116,25 @@ suite "DEBRA Batched Retire/Reclaim API":
     discard reclaimNow(manager)
     check destroyedCount == 1
 
-  test "withPin runs body to completion and unpins":
+  test "pinScope runs body to completion and unpins":
     var ran = false
-    handle.withPin:
+    block:
+      var scope {.used.} = pinScope(unpinned(handle))
       ran = true
       check manager.threads[handle.idx].pinned.load(moAcquire)
     check ran
     check not manager.threads[handle.idx].pinned.load(moAcquire)
 
-  test "withPin unpins on exception":
+  test "pinScope unpins on exception":
     let n = cast[Node](alloc0(sizeof(NodeObj)))
 
     expect(ValueError):
-      handle.withPin:
-        it.retire(n, destroyNode)
-        raise newException(ValueError, "boom")
+      var scope = pinScope(unpinned(handle))
+      var ready = retireReady(scope.state)
+      ready.retire(n, destroyNode)
+      raise newException(ValueError, "boom")
 
-    # Thread is unpinned despite the raise
+    # Thread is unpinned despite the raise (scope's =destroy ran during unwind)
     check not manager.threads[handle.idx].pinned.load(moAcquire)
 
     # Reclamation can still proceed
@@ -138,16 +144,16 @@ suite "DEBRA Batched Retire/Reclaim API":
     discard reclaimNow(manager)
     check destroyedCount == 1
 
-  test "nested withPin on same handle raises AssertionDefect under debug":
+  test "nested pinScope on same handle raises AssertionDefect under debug":
     # `assert` is active unless built with -d:release / -d:danger.
     # Tests typically run with debug-friendly builds; only enforce when active.
     when compileOption("assertions"):
-      expect(AssertionDefect):
-        handle.withPin:
-          handle.withPin:
-            discard
-      # After the AssertionDefect, the outer withPin's finally still ran
-      # and unpinned the thread.
+      block:
+        var outer {.used.} = pinScope(unpinned(handle))
+        expect(AssertionDefect):
+          var inner {.used.} = pinScope(unpinned(handle))
+        # outer is still alive; its =destroy runs at block exit and
+        # unpins the slot.
       check not manager.threads[handle.idx].pinned.load(moAcquire)
 
   test "reclaimNow returns 0 when not safe yet":
@@ -159,9 +165,11 @@ suite "DEBRA Batched Retire/Reclaim API":
     let n1 = cast[Node](alloc0(sizeof(NodeObj)))
     let n2 = cast[Node](alloc0(sizeof(NodeObj)))
 
-    handle.withPin:
-      it.retire(n1, destroyNode)
-      it.retire(n2, destroyNode)
+    block:
+      var scope = pinScope(unpinned(handle))
+      var ready = retireReady(scope.state)
+      ready.retire(n1, destroyNode)
+      ready.retire(n2, destroyNode)
 
     advance(manager)
     advance(manager)
@@ -207,9 +215,11 @@ suite "DEBRA Batched Retire/Reclaim API":
     # End-to-end: retire, advance via cadence helper, reclaim observes safe.
     let n1 = cast[Node](alloc0(sizeof(NodeObj)))
     let n2 = cast[Node](alloc0(sizeof(NodeObj)))
-    handle.withPin:
-      it.retire(n1, destroyNode)
-      it.retire(n2, destroyNode)
+    block:
+      var scope = pinScope(unpinned(handle))
+      var ready = retireReady(scope.state)
+      ready.retire(n1, destroyNode)
+      ready.retire(n2, destroyNode)
     # Drive enough cadence ticks (n=2) to advance the epoch past safe.
     for i in 1 .. 6:
       handle.advanceEvery(2)
@@ -225,8 +235,10 @@ suite "DEBRA Batched Retire/Reclaim API":
       node.value = i
       items.add((cast[pointer](node), destroyNode))
 
-    handle.withPin:
-      it.retireBatch(items)
+    block:
+      var scope = pinScope(unpinned(handle))
+      var ready = retireReady(scope.state)
+      ready.retireBatch(items)
 
     check not manager.threads[handle.idx].pinned.load(moAcquire)
 

--- a/tests/t_guard.nim
+++ b/tests/t_guard.nim
@@ -6,10 +6,10 @@ import debra/typestates/manager
 import debra/typestates/guard
 
 suite "EpochGuard typestate":
-  var mgr: DebraManager[4]
+  var mgr: DebraManager[4, ccSingle]
 
   setup:
-    mgr = DebraManager[4]()
+    mgr = DebraManager[4, ccSingle]()
     discard uninitializedManager(addr mgr).initialize()
 
   test "unpinned creates Unpinned state":

--- a/tests/t_guard.nim
+++ b/tests/t_guard.nim
@@ -13,36 +13,36 @@ suite "EpochGuard typestate":
     discard uninitializedManager(addr mgr).initialize()
 
   test "unpinned creates Unpinned state":
-    let handle = ThreadHandle[4](idx: 0, manager: addr mgr)
+    let handle = ThreadHandle[4, ccSingle](idx: 0, manager: addr mgr)
     let u = unpinned(handle)
-    check u is Unpinned[4]
+    check u is Unpinned[4, ccSingle]
 
   test "pin transitions Unpinned to Pinned":
-    let handle = ThreadHandle[4](idx: 0, manager: addr mgr)
+    let handle = ThreadHandle[4, ccSingle](idx: 0, manager: addr mgr)
     let u = unpinned(handle)
     let p = u.pin()
-    check p is Pinned[4]
+    check p is Pinned[4, ccSingle]
     check mgr.threads[0].pinned.load(moAcquire) == true
 
   test "unpin transitions Pinned to UnpinResult":
-    let handle = ThreadHandle[4](idx: 0, manager: addr mgr)
+    let handle = ThreadHandle[4, ccSingle](idx: 0, manager: addr mgr)
     let p = unpinned(handle).pin()
     let result = p.unpin()
     check result.kind == uUnpinned
     check mgr.threads[0].pinned.load(moAcquire) == false
 
   test "unpin detects neutralization":
-    let handle = ThreadHandle[4](idx: 0, manager: addr mgr)
+    let handle = ThreadHandle[4, ccSingle](idx: 0, manager: addr mgr)
     let p = unpinned(handle).pin()
     mgr.threads[0].neutralized.store(true, moRelease)
     let result = p.unpin()
     check result.kind == uNeutralized
 
   test "acknowledge transitions Neutralized to Unpinned":
-    let handle = ThreadHandle[4](idx: 0, manager: addr mgr)
+    let handle = ThreadHandle[4, ccSingle](idx: 0, manager: addr mgr)
     let p = unpinned(handle).pin()
     mgr.threads[0].neutralized.store(true, moRelease)
     let result = p.unpin()
     let u = result.neutralized.acknowledge()
-    check u is Unpinned[4]
+    check u is Unpinned[4, ccSingle]
     check mgr.threads[0].neutralized.load(moAcquire) == false

--- a/tests/t_manager_cc_surface.nim
+++ b/tests/t_manager_cc_surface.nim
@@ -1,0 +1,62 @@
+## Surface-ergonomics fixture for the 0.8.0 "Step 8" widening: verifies
+## that `bindClient`, `unbindClient`, `clientCount`, `advance`,
+## `currentEpoch`, and `initDebraManager` accept both `ccSingle` and
+## `ccMulti` cardinality on `DebraManager` without triggering Nim's
+## default-CC `type mismatch`.
+##
+## ccSingle behavior is already covered by `t_bind_client.nim` and other
+## suites; this file exists to lock in the new ccMulti compile shape.
+
+import unittest2
+
+import debra
+import debra/types
+import debra/typestates/cardinality
+
+suite "DebraManager CC surface (0.8.0 Step 8 widening)":
+  test "initDebraManager[N]() defaults to ccSingle":
+    var mgr = initDebraManager[4]()
+    static:
+      doAssert typeof(mgr) is DebraManager[4, ccSingle]
+    check mgr.clientCount() == 0
+
+  test "initDebraManager[N, ccSingle]() yields a ccSingle manager":
+    var mgr = initDebraManager[4, ccSingle]()
+    static:
+      doAssert typeof(mgr) is DebraManager[4, ccSingle]
+    check mgr.clientCount() == 0
+
+  test "initDebraManager[N, ccMulti]() yields a ccMulti manager":
+    var mgr = initDebraManager[4, ccMulti]()
+    static:
+      doAssert typeof(mgr) is DebraManager[4, ccMulti]
+    check mgr.clientCount() == 0
+
+  test "bindClient / unbindClient / clientCount accept ccMulti managers":
+    var mgr = initDebraManager[4, ccMulti]()
+    mgr.bindClient()
+    mgr.bindClient()
+    check mgr.clientCount() == 2
+    mgr.unbindClient()
+    mgr.unbindClient()
+    check mgr.clientCount() == 0
+
+  test "advance / currentEpoch accept ccMulti managers":
+    var mgr = initDebraManager[4, ccMulti]()
+    let e0 = mgr.currentEpoch()
+    mgr.advance()
+    let e1 = mgr.currentEpoch()
+    check e1 == e0 + 1
+
+  test "ccSingle and ccMulti managers are distinct compile-time types":
+    var mgrSingle = initDebraManager[4, ccSingle]()
+    var mgrMulti = initDebraManager[4, ccMulti]()
+    static:
+      doAssert typeof(mgrSingle) isnot typeof(mgrMulti)
+    # Touch both to keep the values used and exercise the surface.
+    mgrSingle.bindClient()
+    mgrMulti.bindClient()
+    check mgrSingle.clientCount() == 1
+    check mgrMulti.clientCount() == 1
+    mgrSingle.unbindClient()
+    mgrMulti.unbindClient()

--- a/tests/t_manager_cc_surface.nim
+++ b/tests/t_manager_cc_surface.nim
@@ -60,3 +60,119 @@ suite "DebraManager CC surface (0.8.0 Step 8 widening)":
     check mgrMulti.clientCount() == 1
     mgrSingle.unbindClient()
     mgrMulti.unbindClient()
+
+suite "Typestate-context CC threading (0.8.0 Step 8 completion)":
+  # Step 3.3.4.5a-2 completes the surface widening on the 5 typestate
+  # context types (ReclaimContext, AdvanceContext, ManagerContext,
+  # NeutralizeContext, SlotContext) that were missed in the original
+  # 3.3.4.5a pass. This suite locks in that the ccMulti cardinality
+  # propagates end-to-end through the typestate context builders and
+  # transitions, mirroring the t_pinned_scope ccMulti fixture for the
+  # already-widened guard/retire/pinned_scope contexts.
+
+  test "uninitializedManager / initialize / shutdown accept ccMulti":
+    var mgr = initDebraManager[4, ccMulti]()
+    let uninit = uninitializedManager(addr mgr)
+    static:
+      doAssert typeof(uninit) is ManagerUninitialized[4, ccMulti]
+    let ready = uninit.initialize()
+    static:
+      doAssert typeof(ready) is ManagerReady[4, ccMulti]
+    let shutdown = ready.shutdown()
+    static:
+      doAssert typeof(shutdown) is ManagerShutdown[4, ccMulti]
+
+  test "advanceCurrent / advance / complete accept ccMulti":
+    var mgr = initDebraManager[4, ccMulti]()
+    let current = advanceCurrent(addr mgr)
+    static:
+      doAssert typeof(current) is Current[4, ccMulti]
+    let advanced = current.advance().complete()
+    static:
+      doAssert typeof(advanced) is Advanced[4, ccMulti]
+    check advanced.newEpoch == advanced.oldEpoch + 1'u64
+
+  test "freeSlot / claim / activate / drain / release accept ccMulti":
+    var mgr = initDebraManager[4, ccMulti]()
+    let free0 = freeSlot[4, ccMulti](0, addr mgr)
+    static:
+      doAssert typeof(free0) is Free[4, ccMulti]
+    let claiming = free0.claim()
+    static:
+      doAssert typeof(claiming) is Claiming[4, ccMulti]
+    let active = claiming.activate()
+    static:
+      doAssert typeof(active) is Active[4, ccMulti]
+    check active.idx == 0
+    let draining = active.drain()
+    static:
+      doAssert typeof(draining) is Draining[4, ccMulti]
+    let free1 = draining.release()
+    static:
+      doAssert typeof(free1) is Free[4, ccMulti]
+
+  test "scanStart / loadEpoch / scanAndSignal accept ccMulti":
+    var mgr = initDebraManager[4, ccMulti]()
+    let s = scanStart(addr mgr)
+    static:
+      doAssert typeof(s) is ScanStart[4, ccMulti]
+    let scanning = s.loadEpoch()
+    static:
+      doAssert typeof(scanning) is Scanning[4, ccMulti]
+    let complete = scanning.scanAndSignal()
+    static:
+      doAssert typeof(complete) is ScanComplete[4, ccMulti]
+    # No registered threads -> no signals sent.
+    check complete.signalsSent == 0
+
+  test "reclaimStart(handle) chain accepts ccMulti — load-bearing block site":
+    # This is the lfq v5.0.0 reclaim.nim:97 shape: a ccMulti handle reaches
+    # reclaimStart, which previously required a ccSingle context and rejected
+    # the ccMulti manager. Verifies the full chain reclaimStart -> loadEpochs
+    # -> checkSafe -> tryReclaim propagates CC end-to-end.
+    var mgr = initDebraManager[4, ccMulti]()
+    discard uninitializedManager(addr mgr).initialize()
+    let handle = registerThread(mgr)
+    static:
+      doAssert typeof(handle) is ThreadHandle[4, ccMulti]
+    let s = reclaimStart(handle)
+    static:
+      doAssert typeof(s) is ReclaimStart[4, ccMulti]
+    let loaded = s.loadEpochs()
+    static:
+      doAssert typeof(loaded) is EpochsLoaded[4, ccMulti]
+    let checked = loaded.checkSafe()
+    static:
+      doAssert typeof(checked) is ReclaimCheck[4, ccMulti]
+    # Brand-new manager, advance twice so safeEpoch > 1 and the ReclaimReady
+    # branch is the one observed.
+    mgr.advance()
+    mgr.advance()
+    let count = reclaimNow(handle)
+    check count == 0 # nothing retired
+
+  test "reclaimNow(handle) end-to-end on ccMulti propagates through tryReclaim":
+    # Exercises the convenience wrapper path that lockfreequeues v5.0.0
+    # multi-consumer pop hits at its reclaimNow tail.
+    var mgr = initDebraManager[4, ccMulti]()
+    discard uninitializedManager(addr mgr).initialize()
+    let handle = registerThread(mgr)
+    proc dtor(p: pointer) {.nimcall.} =
+      dealloc(p)
+
+    block:
+      var scope = pinScope(unpinned(handle))
+      var ready = retireReady(scope.state)
+      ready.retire(alloc0(8), dtor)
+    mgr.advance()
+    mgr.advance()
+    let reclaimed = reclaimNow(handle)
+    check reclaimed == 1
+
+  test "reclaimNow(manager) legacy form accepts ccMulti":
+    var mgr = initDebraManager[4, ccMulti]()
+    discard uninitializedManager(addr mgr).initialize()
+    discard registerThread(mgr)
+    # No retires yet, no advance: returns 0 cleanly without a ccSingle mismatch.
+    let n = reclaimNow(mgr)
+    check n == 0

--- a/tests/t_manager_typestate.nim
+++ b/tests/t_manager_typestate.nim
@@ -6,12 +6,12 @@ import debra/typestates/manager
 
 suite "Manager typestate":
   test "uninitializedManager creates ManagerUninitialized":
-    var mgr: DebraManager[4]
+    var mgr: DebraManager[4, ccSingle]
     let ctx = uninitializedManager(addr mgr)
     check ctx is ManagerUninitialized[4]
 
   test "initialize transitions to ManagerReady":
-    var mgr: DebraManager[4]
+    var mgr: DebraManager[4, ccSingle]
     let uninit = uninitializedManager(addr mgr)
     let ready = uninit.initialize()
     check ready is ManagerReady[4]
@@ -19,7 +19,7 @@ suite "Manager typestate":
     check mgr.globalEpoch.load(moRelaxed) == 1'u64
 
   test "shutdown transitions to ManagerShutdown":
-    var mgr: DebraManager[4]
+    var mgr: DebraManager[4, ccSingle]
     let ready = uninitializedManager(addr mgr).initialize()
     let shutdown = ready.shutdown()
     check shutdown is ManagerShutdown[4]

--- a/tests/t_neutralize.nim
+++ b/tests/t_neutralize.nim
@@ -46,10 +46,10 @@ proc helperThreadProcCrossSlot() {.thread.} =
   threadLocalIdx = 0
 
 suite "Neutralize typestate":
-  var mgr: DebraManager[4]
+  var mgr: DebraManager[4, ccSingle]
 
   setup:
-    mgr = DebraManager[4]()
+    mgr = DebraManager[4, ccSingle]()
     mgr.globalEpoch.store(1'u64, moRelaxed)
     mgr.activeThreadMask.store(0'u64, moRelaxed)
     for i in 0 ..< 4:

--- a/tests/t_pinned_scope.nim
+++ b/tests/t_pinned_scope.nim
@@ -42,6 +42,7 @@ suite "PinnedScope happy path + lifecycle":
     proc earlyReturn(h: ThreadHandle[4]) =
       var scope {.used.} = pinScope(unpinned(h))
       return
+
     earlyReturn(handle)
     check manager.threads[handle.idx].pinned.load(moAcquire) == false
 

--- a/tests/t_pinned_scope.nim
+++ b/tests/t_pinned_scope.nim
@@ -39,7 +39,7 @@ suite "PinnedScope happy path + lifecycle":
     check manager.threads[handle.idx].pinned.load(moAcquire) == false
 
   test "=destroy fires on early return":
-    proc earlyReturn(h: ThreadHandle[4]) =
+    proc earlyReturn(h: ThreadHandle[4, ccSingle]) =
       var scope {.used.} = pinScope(unpinned(h))
       return
 

--- a/tests/t_pinned_scope.nim
+++ b/tests/t_pinned_scope.nim
@@ -1,0 +1,171 @@
+## Tests for the PinnedScope RAII guard (debra/typestates/pinned_scope).
+##
+## Cases cover the 10 scenarios spelled in the v0.8.0 phase-1 plan §4
+## Step 6: happy-path, =destroy on early return, =destroy on exception,
+## =destroy after a Neutralized cycle, nested-pin AssertionDefect,
+## no-copy compile rejection, move-safety, epoch snapshot, loop of
+## retire, and ccMulti cardinality.
+
+import unittest2
+
+import debra
+import debra/atomics
+import debra/typestates/cardinality
+import debra/typestates/guard
+import debra/typestates/registration
+
+type NodeObj = object
+  value: int
+
+var destroyedCount = 0
+
+proc dtor(p: pointer) {.nimcall.} =
+  inc destroyedCount
+  dealloc(p)
+
+suite "PinnedScope happy path + lifecycle":
+  setup:
+    var manager {.inject.} = initDebraManager[4]()
+    setGlobalManager(addr manager)
+    let handle {.inject.} = registerThread(manager)
+    destroyedCount = 0
+
+  test "happy path: block exit unpins via =destroy":
+    block:
+      var scope = pinScope(unpinned(handle))
+      check manager.threads[handle.idx].pinned.load(moAcquire) == true
+      discard scope.consumed
+    # =destroy ran on block exit; slot is unpinned.
+    check manager.threads[handle.idx].pinned.load(moAcquire) == false
+
+  test "=destroy fires on early return":
+    proc earlyReturn(h: ThreadHandle[4]) =
+      var scope {.used.} = pinScope(unpinned(h))
+      return
+    earlyReturn(handle)
+    check manager.threads[handle.idx].pinned.load(moAcquire) == false
+
+  test "=destroy fires on exception":
+    expect(ValueError):
+      var scope {.used.} = pinScope(unpinned(handle))
+      raise newException(ValueError, "boom")
+    # The thrown exception unwinds past `scope`; its `=destroy` ran on
+    # the way out and unpinned the slot.
+    check manager.threads[handle.idx].pinned.load(moAcquire) == false
+
+  test "=destroy clears Neutralized state via acknowledge + close":
+    # Force the slot's neutralized flag so unpin returns Neutralized.
+    manager.threads[handle.idx].neutralized.store(true, moRelease)
+    block:
+      var scope {.used.} = pinScope(unpinned(handle))
+      check manager.threads[handle.idx].pinned.load(moAcquire) == true
+    # =destroy walked the Neutralized arm: pinned cleared, neutralized
+    # cleared by acknowledge().
+    check manager.threads[handle.idx].pinned.load(moAcquire) == false
+    check manager.threads[handle.idx].neutralized.load(moAcquire) == false
+
+  test "nested pinScope on same handle hits AssertionDefect":
+    # The constructor's doAssert fires only when assertions are active.
+    when compileOption("assertions"):
+      var outer {.used.} = pinScope(unpinned(handle))
+      expect(AssertionDefect):
+        var inner {.used.} = pinScope(unpinned(handle))
+      # outer is still alive; its destructor runs at suite teardown.
+
+  test "no-copy semantics: PinnedScope has =copy disabled":
+    # NOTE: `=copy {.error.}` is a codegen-phase rejection, not a
+    # semantic-phase one. `compiles(var b = a)` returns TRUE for such
+    # types even though emitting the copy fails. The hard compile-fail
+    # is therefore exercised in tests/should_fail/t_pinned_scope_copy.nim
+    # via `nim c` + runner substring check. Here we record the runtime
+    # invariant that pairs with non-copyability: a freshly constructed
+    # scope is unconsumed, and moving it (Case 7) marks the source
+    # consumed = true so a stray `=destroy` cannot double-unpin.
+    var scope {.used.} = pinScope(unpinned(handle))
+    check scope.consumed == false
+
+  test "move-safety: moved-from scope destructor is a no-op":
+    # The =wasMoved hook on PinnedScope marks the moved-from value as
+    # consumed=true so a re-entrant =destroy is a no-op. refc does not
+    # honour custom =wasMoved hooks (move semantics are ORC/ARC-family
+    # only), so this regression check runs under managed-memory backends
+    # that respect the move hook.
+    when defined(gcOrc) or defined(gcArc) or defined(gcAtomicArc):
+      var a = pinScope(unpinned(handle))
+      var b = move(a)
+      check a.consumed == true
+      check b.consumed == false
+      discard b
+      discard a
+    else:
+      # refc: skip the move-hook check; document via a trivial assertion
+      # so the case stays at 10 across backends.
+      check true
+
+  test "epoch snapshot: scope captures global epoch once":
+    var scope = pinScope(unpinned(handle))
+    let epoch1 = scope.state.epoch
+    # Mutating the global epoch must not change the scope's captured
+    # value: pin samples the global epoch once at construction.
+    advance(manager)
+    advance(manager)
+    let epoch2 = scope.state.epoch
+    check epoch1 == epoch2
+
+  test "loop of retire: multiple retireOnCAS calls inside one scope":
+    var slot: Atomic[ptr NodeObj]
+    let initial = cast[ptr NodeObj](alloc0(sizeof(NodeObj)))
+    initial.value = 0
+    slot.store(initial, moRelease)
+    const Iterations = 4
+
+    var scope = pinScope(unpinned(handle))
+    for i in 1 .. Iterations:
+      let next = cast[ptr NodeObj](alloc0(sizeof(NodeObj)))
+      next.value = i
+      var exp = slot.load(moAcquire)
+      let ok = scope.retireOnCAS(slot, exp, next, dtor)
+      check ok == true
+
+    # N retires queued exactly N items in the current bag.
+    check manager.threads[handle.idx].currentBag != nil
+    check manager.threads[handle.idx].currentBag.count == Iterations
+    # Free the live ptr so the test doesn't leak the final node.
+    let final = slot.load(moAcquire)
+    discard slot.exchange(nil, moAcquireRelease)
+    dealloc(final)
+
+suite "PinnedScope ccMulti cardinality":
+  test "happy path under [MT, ccMulti]":
+    # `initDebraManager` only emits `[MT, ccSingle]`; ccMulti requires
+    # building the manager + driving the manager typestate by hand.
+    var manager: DebraManager[4, ccMulti]
+    manager.globalEpoch.store(1'u64, moRelaxed)
+    manager.activeThreadMask.store(0'u64, moRelaxed)
+    manager.boundClients.store(0, moRelaxed)
+    for i in 0 ..< 4:
+      manager.threads[i].epoch.store(0'u64, moRelaxed)
+      manager.threads[i].pinned.store(false, moRelaxed)
+      manager.threads[i].neutralized.store(false, moRelaxed)
+      manager.threads[i].threadId.store(InvalidThreadId, moRelaxed)
+      manager.threads[i].currentBag = nil
+      manager.threads[i].limboBagTail = nil
+    # NOTE: setGlobalManager has not been widened to accept
+    # `ptr DebraManager[MaxThreads, ccMulti]` yet (step 8 territory).
+    # The ccMulti happy-path test exercises pin/unpin only — no signals,
+    # no neutralize — so a non-published global manager is acceptable.
+
+    let u = unregistered[4, ccMulti](addr manager)
+    var regResult = u.register()
+    var handle: ThreadHandle[4, ccMulti]
+    match regResult:
+      Registered(reg):
+        handle = reg.getHandle()
+      RegistrationFull(_):
+        check false # unreachable under fresh manager.
+
+    block:
+      var scope = pinScope(unpinned(handle))
+      check manager.threads[handle.idx].pinned.load(moAcquire) == true
+      discard scope.consumed
+    check manager.threads[handle.idx].pinned.load(moAcquire) == false

--- a/tests/t_reclaim.nim
+++ b/tests/t_reclaim.nim
@@ -20,10 +20,10 @@ proc allocNode(value: int): pointer =
   cast[pointer](n)
 
 suite "Reclaim typestate":
-  var mgr: DebraManager[4]
+  var mgr: DebraManager[4, ccSingle]
 
   setup:
-    mgr = DebraManager[4]()
+    mgr = DebraManager[4, ccSingle]()
     discard uninitializedManager(addr mgr).initialize()
 
   test "reclaimStart creates ReclaimStart":

--- a/tests/t_reclaim.nim
+++ b/tests/t_reclaim.nim
@@ -27,27 +27,27 @@ suite "Reclaim typestate":
     discard uninitializedManager(addr mgr).initialize()
 
   test "reclaimStart creates ReclaimStart":
-    let handle = ThreadHandle[4](idx: 0, manager: addr mgr)
+    let handle = ThreadHandle[4, ccSingle](idx: 0, manager: addr mgr)
     let s = reclaimStart(handle)
     check s is ReclaimStart[4]
 
   test "loadEpochs computes safe epoch":
     mgr.globalEpoch.store(10'u64, moRelaxed)
-    let handle = ThreadHandle[4](idx: 0, manager: addr mgr)
+    let handle = ThreadHandle[4, ccSingle](idx: 0, manager: addr mgr)
     let loaded = reclaimStart(handle).loadEpochs()
     check loaded is EpochsLoaded[4]
     check loaded.safeEpoch == 10'u64
 
   test "checkSafe returns ReclaimReady when epoch > 1":
     mgr.globalEpoch.store(5'u64, moRelaxed)
-    let handle = ThreadHandle[4](idx: 0, manager: addr mgr)
+    let handle = ThreadHandle[4, ccSingle](idx: 0, manager: addr mgr)
     let check = reclaimStart(handle).loadEpochs().checkSafe()
     check check.kind == rReclaimReady
 
   test "tryReclaim reclaims eligible bags":
     # Setup: retire objects at epoch 1
     mgr.globalEpoch.store(1'u64, moRelaxed)
-    let handle = ThreadHandle[4](idx: 0, manager: addr mgr)
+    let handle = ThreadHandle[4, ccSingle](idx: 0, manager: addr mgr)
     let p = unpinned(handle).pin()
     var ready = retireReady(p)
     for i in 0 ..< 5:
@@ -75,7 +75,7 @@ suite "Reclaim typestate":
     mgr.globalEpoch.store(1'u64, moRelaxed)
 
     # Thread 0: Retire 3 objects at epoch 1
-    let h0 = ThreadHandle[4](idx: 0, manager: addr mgr)
+    let h0 = ThreadHandle[4, ccSingle](idx: 0, manager: addr mgr)
     let p0 = unpinned(h0).pin()
     check p0.epoch == 1
     var ready0 = retireReady(p0)
@@ -88,7 +88,7 @@ suite "Reclaim typestate":
     mgr.globalEpoch.store(2'u64, moRelaxed)
 
     # Thread 1: Retire 4 objects at epoch 2
-    let h1 = ThreadHandle[4](idx: 1, manager: addr mgr)
+    let h1 = ThreadHandle[4, ccSingle](idx: 1, manager: addr mgr)
     let p1 = unpinned(h1).pin()
     check p1.epoch == 2
     var ready1 = retireReady(p1)
@@ -101,7 +101,7 @@ suite "Reclaim typestate":
     mgr.globalEpoch.store(3'u64, moRelaxed)
 
     # Thread 2: Retire 5 objects at epoch 3
-    let h2 = ThreadHandle[4](idx: 2, manager: addr mgr)
+    let h2 = ThreadHandle[4, ccSingle](idx: 2, manager: addr mgr)
     let p2 = unpinned(h2).pin()
     check p2.epoch == 3
     var ready2 = retireReady(p2)
@@ -163,8 +163,8 @@ suite "Reclaim typestate":
     # reclaims; thread 0's bags are untouched.
     mgr.globalEpoch.store(1'u64, moRelaxed)
 
-    let h0 = ThreadHandle[4](idx: 0, manager: addr mgr)
-    let h1 = ThreadHandle[4](idx: 1, manager: addr mgr)
+    let h0 = ThreadHandle[4, ccSingle](idx: 0, manager: addr mgr)
+    let h1 = ThreadHandle[4, ccSingle](idx: 1, manager: addr mgr)
 
     # Thread 0 retires 3 objects at epoch 1
     let p0 = unpinned(h0).pin()
@@ -197,7 +197,7 @@ suite "Reclaim typestate":
     # Retire enough objects to fill 2+ bags, then reclaim. Verifies the new
     # tail-to-current FIFO list management correctly walks all eligible bags.
     mgr.globalEpoch.store(1'u64, moRelaxed)
-    let handle = ThreadHandle[4](idx: 0, manager: addr mgr)
+    let handle = ThreadHandle[4, ccSingle](idx: 0, manager: addr mgr)
     let p = unpinned(handle).pin()
     var ready = retireReady(p)
     let totalObjects = LimboBagSize * 2 + 5 # 133 objects -> 3 bags

--- a/tests/t_registration.nim
+++ b/tests/t_registration.nim
@@ -6,7 +6,7 @@ import debra/typestates/registration
 import debra/typestates/manager
 
 type ConcurrentRegTestData* = object
-  manager: ptr DebraManager[4]
+  manager: ptr DebraManager[4, ccSingle]
   registrationResult: RegisterResult[4]
 
 var
@@ -31,11 +31,11 @@ proc concurrentRegisterProc() {.thread.} =
   globalThreadData[myId].registrationResult = u.register()
 
 suite "Registration typestate":
-  var mgr: DebraManager[4]
+  var mgr: DebraManager[4, ccSingle]
   var ready: ManagerReady[4]
 
   setup:
-    mgr = DebraManager[4]()
+    mgr = DebraManager[4, ccSingle]()
     ready = uninitializedManager(addr mgr).initialize()
 
   test "unregistered creates Unregistered state":

--- a/tests/t_retire.nim
+++ b/tests/t_retire.nim
@@ -21,13 +21,13 @@ suite "Retire typestate":
     discard uninitializedManager(addr mgr).initialize()
 
   test "retireReady from Pinned":
-    let handle = ThreadHandle[4](idx: 0, manager: addr mgr)
+    let handle = ThreadHandle[4, ccSingle](idx: 0, manager: addr mgr)
     let p = unpinned(handle).pin()
     let ready = retireReady(p)
-    check ready is RetireReady[4]
+    check ready is RetireReady[4, ccSingle]
 
   test "retire accepts pointer + destructor":
-    let handle = ThreadHandle[4](idx: 0, manager: addr mgr)
+    let handle = ThreadHandle[4, ccSingle](idx: 0, manager: addr mgr)
     let p = unpinned(handle).pin()
     let ready = retireReady(p)
 
@@ -35,12 +35,12 @@ suite "Retire typestate":
     raw.value = 42
     let retired = ready.retire(cast[pointer](raw), dtor)
 
-    check retired is Retired[4]
+    check retired is Retired[4, ccSingle]
     check mgr.threads[0].currentBag != nil
     check mgr.threads[0].currentBag.count == 1
 
   test "retire multiple pointers fills bag":
-    let handle = ThreadHandle[4](idx: 0, manager: addr mgr)
+    let handle = ThreadHandle[4, ccSingle](idx: 0, manager: addr mgr)
     let p = unpinned(handle).pin()
     var ready = retireReady(p)
 
@@ -53,7 +53,7 @@ suite "Retire typestate":
     check mgr.threads[0].currentBag.count == LimboBagSize
 
   test "retireReadyFromRetired allows chaining":
-    let handle = ThreadHandle[4](idx: 0, manager: addr mgr)
+    let handle = ThreadHandle[4, ccSingle](idx: 0, manager: addr mgr)
     let p = unpinned(handle).pin()
     var ready = retireReady(p)
 
@@ -66,7 +66,7 @@ suite "Retire typestate":
     check mgr.threads[0].currentBag.count == 3
 
   test "pinnedFromRetired round-trips Pinned -> Retired -> Pinned -> unpin":
-    let handle = ThreadHandle[4](idx: 0, manager: addr mgr)
+    let handle = ThreadHandle[4, ccSingle](idx: 0, manager: addr mgr)
     let pinned = unpinned(handle).pin()
     let originalEpoch = pinned.epoch
     let ready = retireReady(pinned)

--- a/tests/t_retire.nim
+++ b/tests/t_retire.nim
@@ -14,10 +14,10 @@ proc dtor(p: pointer) {.nimcall.} =
   dealloc(p)
 
 suite "Retire typestate":
-  var mgr: DebraManager[4]
+  var mgr: DebraManager[4, ccSingle]
 
   setup:
-    mgr = DebraManager[4]()
+    mgr = DebraManager[4, ccSingle]()
     discard uninitializedManager(addr mgr).initialize()
 
   test "retireReady from Pinned":

--- a/tests/t_retire_on_cas.nim
+++ b/tests/t_retire_on_cas.nim
@@ -1,0 +1,216 @@
+## Tests for `PinnedScope.retireOnCAS` and `retireOnPublish`.
+##
+## Cases cover the 9 scenarios spelled in the v0.8.0 phase-1 plan §4
+## Step 6: CAS success/failure, rotation invariant, while-loop shape,
+## ccMulti, retireOnPublish stores + retires, loop of retireOnPublish,
+## retireOnCAS + retireOnPublish interleaved, and the empty-scope
+## no-retire path.
+
+import unittest2
+
+import debra
+import debra/atomics
+import debra/typestates/cardinality
+import debra/typestates/guard
+import debra/typestates/registration
+
+type NodeObj = object
+  value: int
+
+var destroyedCount = 0
+
+proc dtor(p: pointer) {.nimcall.} =
+  inc destroyedCount
+  dealloc(p)
+
+suite "retireOnCAS + retireOnPublish":
+  setup:
+    var manager {.inject.} = initDebraManager[4]()
+    setGlobalManager(addr manager)
+    let handle {.inject.} = registerThread(manager)
+    destroyedCount = 0
+
+  test "retireOnCAS success retires the displaced pointer":
+    var slot: Atomic[ptr NodeObj]
+    let a = cast[ptr NodeObj](alloc0(sizeof(NodeObj)))
+    a.value = 1
+    slot.store(a, moRelease)
+    let b = cast[ptr NodeObj](alloc0(sizeof(NodeObj)))
+    b.value = 2
+
+    var scope = pinScope(unpinned(handle))
+    var exp = slot.load(moAcquire)
+    let ok = scope.retireOnCAS(slot, exp, b, dtor)
+    check ok == true
+    check slot.load(moAcquire) == b
+    check manager.threads[handle.idx].currentBag != nil
+    check manager.threads[handle.idx].currentBag.count == 1
+
+    # Defuse the live pointer so the suite teardown doesn't leak.
+    discard slot.exchange(nil, moAcquireRelease)
+    dealloc(b)
+
+  test "retireOnCAS failure retires nothing":
+    var slot: Atomic[ptr NodeObj]
+    let a = cast[ptr NodeObj](alloc0(sizeof(NodeObj)))
+    a.value = 1
+    slot.store(a, moRelease)
+    let other = cast[ptr NodeObj](alloc0(sizeof(NodeObj)))
+    other.value = 99
+    let b = cast[ptr NodeObj](alloc0(sizeof(NodeObj)))
+    b.value = 2
+
+    var scope = pinScope(unpinned(handle))
+    var exp = other # deliberately wrong expected value
+    let ok = scope.retireOnCAS(slot, exp, b, dtor)
+    check ok == false
+    check slot.load(moAcquire) == a # slot unchanged
+    # No bag should have been allocated.
+    check manager.threads[handle.idx].currentBag == nil
+
+    # Cleanup the unused allocations.
+    dealloc(other)
+    dealloc(b)
+    discard slot.exchange(nil, moAcquireRelease)
+    dealloc(a)
+
+  test "rotation invariant: scope.state.epoch unchanged after retireOnCAS":
+    var slot: Atomic[ptr NodeObj]
+    let a = cast[ptr NodeObj](alloc0(sizeof(NodeObj)))
+    slot.store(a, moRelease)
+    let b = cast[ptr NodeObj](alloc0(sizeof(NodeObj)))
+
+    var scope = pinScope(unpinned(handle))
+    let epoch1 = scope.state.epoch
+    var exp = slot.load(moAcquire)
+    discard scope.retireOnCAS(slot, exp, b, dtor)
+    let epoch2 = scope.state.epoch
+    # Rotation through RetireReady -> Retired -> Pinned does NOT advance
+    # the epoch; the slot's pinned flag is unchanged.
+    check epoch1 == epoch2
+    check manager.threads[handle.idx].pinned.load(moAcquire) == true
+
+    discard slot.exchange(nil, moAcquireRelease)
+    dealloc(b)
+
+  test "while-loop shape: CAS retry to publish a successor":
+    var slot: Atomic[ptr NodeObj]
+    let initial = cast[ptr NodeObj](alloc0(sizeof(NodeObj)))
+    initial.value = 0
+    slot.store(initial, moRelease)
+    let successor = cast[ptr NodeObj](alloc0(sizeof(NodeObj)))
+    successor.value = 1
+
+    var scope = pinScope(unpinned(handle))
+    var loops = 0
+    while true:
+      inc loops
+      let exp = slot.load(moAcquire)
+      if scope.retireOnCAS(slot, exp, successor, dtor):
+        break
+      check loops < 16 # guard against runaway retries
+    check slot.load(moAcquire) == successor
+    check manager.threads[handle.idx].currentBag.count == 1
+
+    discard slot.exchange(nil, moAcquireRelease)
+    dealloc(successor)
+
+  test "retireOnCAS under [MT, ccMulti]":
+    var mgr: DebraManager[4, ccMulti]
+    mgr.globalEpoch.store(1'u64, moRelaxed)
+    mgr.activeThreadMask.store(0'u64, moRelaxed)
+    mgr.boundClients.store(0, moRelaxed)
+    for i in 0 ..< 4:
+      mgr.threads[i].epoch.store(0'u64, moRelaxed)
+      mgr.threads[i].pinned.store(false, moRelaxed)
+      mgr.threads[i].neutralized.store(false, moRelaxed)
+      mgr.threads[i].threadId.store(InvalidThreadId, moRelaxed)
+      mgr.threads[i].currentBag = nil
+      mgr.threads[i].limboBagTail = nil
+    # NOTE: setGlobalManager not widened to ccMulti yet; ccMulti retire
+    # path does not require it.
+
+    let u = unregistered[4, ccMulti](addr mgr)
+    var regResult = u.register()
+    var mhandle: ThreadHandle[4, ccMulti]
+    match regResult:
+      Registered(reg):
+        mhandle = reg.getHandle()
+      RegistrationFull(_):
+        check false
+
+    var slot: Atomic[ptr NodeObj]
+    let a = cast[ptr NodeObj](alloc0(sizeof(NodeObj)))
+    slot.store(a, moRelease)
+    let b = cast[ptr NodeObj](alloc0(sizeof(NodeObj)))
+
+    block:
+      var scope = pinScope(unpinned(mhandle))
+      var exp = slot.load(moAcquire)
+      let ok = scope.retireOnCAS(slot, exp, b, dtor)
+      check ok == true
+    check mgr.threads[mhandle.idx].pinned.load(moAcquire) == false
+
+    discard slot.exchange(nil, moAcquireRelease)
+    dealloc(b)
+
+  test "retireOnPublish stores and retires the displaced value":
+    var slot: Atomic[ptr NodeObj]
+    let a = cast[ptr NodeObj](alloc0(sizeof(NodeObj)))
+    a.value = 1
+    slot.store(a, moRelease)
+    let b = cast[ptr NodeObj](alloc0(sizeof(NodeObj)))
+    b.value = 2
+
+    var scope = pinScope(unpinned(handle))
+    scope.retireOnPublish(slot, b, dtor)
+    check slot.load(moAcquire) == b
+    check manager.threads[handle.idx].currentBag != nil
+    check manager.threads[handle.idx].currentBag.count == 1
+
+    discard slot.exchange(nil, moAcquireRelease)
+    dealloc(b)
+
+  test "loop of retireOnPublish queues N retires":
+    var slot: Atomic[ptr NodeObj]
+    let initial = cast[ptr NodeObj](alloc0(sizeof(NodeObj)))
+    slot.store(initial, moRelease)
+    const N = 5
+
+    var scope = pinScope(unpinned(handle))
+    for i in 1 .. N:
+      let next = cast[ptr NodeObj](alloc0(sizeof(NodeObj)))
+      next.value = i
+      scope.retireOnPublish(slot, next, dtor)
+    check manager.threads[handle.idx].currentBag.count == N
+
+    let final = slot.load(moAcquire)
+    discard slot.exchange(nil, moAcquireRelease)
+    dealloc(final)
+
+  test "retireOnCAS + retireOnPublish interleaved within one scope":
+    var slot: Atomic[ptr NodeObj]
+    let initial = cast[ptr NodeObj](alloc0(sizeof(NodeObj)))
+    initial.value = 0
+    slot.store(initial, moRelease)
+    let viaCas = cast[ptr NodeObj](alloc0(sizeof(NodeObj)))
+    viaCas.value = 1
+    let viaPublish = cast[ptr NodeObj](alloc0(sizeof(NodeObj)))
+    viaPublish.value = 2
+
+    var scope = pinScope(unpinned(handle))
+    var exp = slot.load(moAcquire)
+    check scope.retireOnCAS(slot, exp, viaCas, dtor) == true
+    scope.retireOnPublish(slot, viaPublish, dtor)
+    check slot.load(moAcquire) == viaPublish
+    check manager.threads[handle.idx].currentBag.count == 2
+
+    discard slot.exchange(nil, moAcquireRelease)
+    dealloc(viaPublish)
+
+  test "empty scope: no retire calls means no bag allocation":
+    block:
+      var scope {.used.} = pinScope(unpinned(handle))
+      # No retire calls inside the scope.
+    check manager.threads[handle.idx].pinned.load(moAcquire) == false
+    check manager.threads[handle.idx].currentBag == nil

--- a/tests/t_retire_on_cas.nim
+++ b/tests/t_retire_on_cas.nim
@@ -105,7 +105,7 @@ suite "retireOnCAS + retireOnPublish":
     var loops = 0
     while true:
       inc loops
-      let exp = slot.load(moAcquire)
+      var exp = slot.load(moAcquire)
       if scope.retireOnCAS(slot, exp, successor, dtor):
         break
       check loops < 16 # guard against runaway retries

--- a/tests/t_signal.nim
+++ b/tests/t_signal.nim
@@ -38,7 +38,7 @@ suite "Signal Handler":
     ## flags untouched. This test asserts both halves.
 
     # Use 4 thread slots so we exercise a non-zero index.
-    var mgr: DebraManager[4]
+    var mgr: DebraManager[4, ccSingle]
     mgr.globalEpoch.store(1'u64, moRelaxed)
     mgr.activeThreadMask.store(0'u64, moRelaxed)
     for i in 0 ..< 4:

--- a/tests/t_slot.nim
+++ b/tests/t_slot.nim
@@ -5,7 +5,7 @@ import debra/types
 import debra/typestates/slot
 
 suite "ThreadSlot typestate":
-  var mgr: DebraManager[4]
+  var mgr: DebraManager[4, ccSingle]
 
   setup:
     mgr = initDebraManager[4]()

--- a/tests/test.nim
+++ b/tests/test.nim
@@ -24,3 +24,4 @@ import ./t_item_processing
 import ./t_lockfree_stack_typestates
 import ./t_backoff
 import ./t_bind_client
+import ./t_manager_cc_surface

--- a/tests/test.nim
+++ b/tests/test.nim
@@ -8,6 +8,8 @@ import ./t_manager_typestate
 import ./t_registration
 import ./t_guard
 import ./t_retire
+import ./t_pinned_scope
+import ./t_retire_on_cas
 import ./t_reclaim
 import ./t_neutralize
 import ./t_advance


### PR DESCRIPTION
nim-debra 0.8.0 introduces the `PinnedScope` RAII guard and a `PinScopeCardinality` (`CC`) generic axis threaded through the typestate surface, and raises the `typestates` dependency floor to `>= 0.9.3`.

## Highlights

**`PinnedScope[MT, CC]` RAII guard** — `=destroy` runs unpin + close automatically on scope exit (including early-return / exception paths). Constructed via `pinScope(unpinned(handle))`. Supports a `retireReady(scope.state)` retire chain so `discard ready.retire(ptr, dtor)` works inside a scope without leaving the pinned axis.

**`PinScopeCardinality` (`ccSingle` / `ccMulti`)** — a new phantom generic parameter (default `ccSingle`) threaded through nine typestate axis types (`ThreadHandle`, `Pinned`, `RetireReady`, `Unpinned`, `Neutralized`, `Retired`, `Registered`, `DebraManager`, `PinnedScope`) and five typestate context types (`ReclaimContext`, `AdvanceContext`, `ManagerContext`, `NeutralizeContext`, `SlotContext`). The `ccSingle` default preserves source-compatibility for every existing 0.7.x call site; multi-pin patterns opt in with explicit `[N, ccMulti]`.

**`withPin` deprecated** — replaced by the `PinnedScope` form; still compiles in 0.8.0 with a deprecation warning. 17 internal sites migrated.

**`EpochGuardContext` gains a `Closed` terminal state** — the full guard lifecycle is now `Pinned → Unpinned → Closed`, exercised by `PinnedScope.=destroy`.

## Dependency

`typestates` floor pinned to `>= 0.9.3`: `PinnedScope.=destroy`'s `destructorTransition` depends on the typestates bracket-asymmetry fix, which is absent from the docs-only 0.9.1 release and present only in released 0.9.3 (which consolidates the never-released 0.9.2).

## Verification

The full suite — 242 tests per backend across orc / arc / atomicArc / refc / cpp — passes against **registry-resolved** typestates 0.9.3 with the local path override disabled, confirming the published-dependency path is sound.
